### PR TITLE
fix: use sample variance in AnomalyDetector (Bessel's correction)

### DIFF
--- a/sdk/agentlens/anomaly.py
+++ b/sdk/agentlens/anomaly.py
@@ -453,7 +453,8 @@ class AnomalyDetector:
         """Compute statistical baseline from a list of values."""
         n = len(values)
         mean = sum(values) / n
-        variance = sum((v - mean) ** 2 for v in values) / n  # population variance
+        # Use sample variance (Bessel's correction) — we're estimating from a sample
+        variance = sum((v - mean) ** 2 for v in values) / (n - 1) if n > 1 else 0.0
         std_dev = math.sqrt(variance)
         return MetricBaseline(
             name=name,


### PR DESCRIPTION
Fixes #21

Population variance (dividing by n) underestimates true variance, especially with small sample sizes (n=3-10). This caused the 2σ threshold to effectively become ~1.63σ, roughly doubling false positive rates.

Changes:
- Switch from population variance (n) to sample variance (n-1)
- Add n>1 guard for single-sample edge case