### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with asyncio.run()

### DIFF
--- a/sdk/tests/test_decorators.py
+++ b/sdk/tests/test_decorators.py
@@ -67,7 +67,7 @@ class TestTrackAgent:
             return x + 1
 
         with patch("agentlens.track") as mock_track:
-            result = asyncio.get_event_loop().run_until_complete(async_agent(10))
+            result = asyncio.run(async_agent(10))
             assert result == 11
             mock_track.assert_called_once()
 
@@ -78,7 +78,7 @@ class TestTrackAgent:
 
         with patch("agentlens.track") as mock_track:
             with pytest.raises(RuntimeError, match="async boom"):
-                asyncio.get_event_loop().run_until_complete(async_fail())
+                asyncio.run(async_fail())
             call_kwargs = mock_track.call_args[1]
             assert call_kwargs["event_type"] == "agent_error"
 
@@ -142,7 +142,7 @@ class TestTrackToolCall:
             return x
 
         with patch("agentlens.track") as mock_track:
-            result = asyncio.get_event_loop().run_until_complete(async_tool(42))
+            result = asyncio.run(async_tool(42))
             assert result == 42
             mock_track.assert_called_once()
 

--- a/sdk/tests/test_decorators_extended.py
+++ b/sdk/tests/test_decorators_extended.py
@@ -130,7 +130,7 @@ class TestTrackAgentAsyncParams:
             return x
 
         with patch("agentlens.track") as mock_track:
-            result = asyncio.get_event_loop().run_until_complete(agent(42))
+            result = asyncio.run(agent(42))
             assert result == 42
             kw = mock_track.call_args[1]
             assert kw["model"] == "claude-3"
@@ -141,7 +141,7 @@ class TestTrackAgentAsyncParams:
             return "hi"
 
         with patch("agentlens.track") as mock_track:
-            asyncio.get_event_loop().run_until_complete(agent())
+            asyncio.run(agent())
             kw = mock_track.call_args[1]
             assert "my-async-agent" in kw["reasoning"]
 
@@ -152,7 +152,7 @@ class TestTrackAgentAsyncParams:
 
         with patch("agentlens.track") as mock_track:
             with pytest.raises(KeyError):
-                asyncio.get_event_loop().run_until_complete(async_type_error())
+                asyncio.run(async_type_error())
             kw = mock_track.call_args[1]
             assert kw["output_data"]["error_type"] == "KeyError"
 
@@ -169,7 +169,7 @@ class TestTrackAgentAsyncParams:
             return "ok"
 
         with patch("agentlens.track", side_effect=RuntimeError("not init")):
-            result = asyncio.get_event_loop().run_until_complete(safe_async())
+            result = asyncio.run(safe_async())
             assert result == "ok"
 
 
@@ -290,7 +290,7 @@ class TestTrackToolCallAsync:
             return f"found: {q}"
 
         with patch("agentlens.track") as mock_track:
-            result = asyncio.get_event_loop().run_until_complete(search("test"))
+            result = asyncio.run(search("test"))
             assert result == "found: test"
             kw = mock_track.call_args[1]
             assert kw["tool_name"] == "web_lookup"
@@ -302,7 +302,7 @@ class TestTrackToolCallAsync:
 
         with patch("agentlens.track") as mock_track:
             with pytest.raises(ConnectionError):
-                asyncio.get_event_loop().run_until_complete(fail_tool())
+                asyncio.run(fail_tool())
             kw = mock_track.call_args[1]
             assert kw["event_type"] == "tool_error"
 
@@ -319,7 +319,7 @@ class TestTrackToolCallAsync:
             return 42
 
         with patch("agentlens.track", side_effect=RuntimeError("not init")):
-            result = asyncio.get_event_loop().run_until_complete(safe_tool())
+            result = asyncio.run(safe_tool())
             assert result == 42
 
 


### PR DESCRIPTION
Replaces all 9 occurrences of deprecated asyncio.get_event_loop().run_until_complete() with asyncio.run() in test files. Fixes DeprecationWarning on Python 3.10+ and RuntimeError on Python 3.12+.