### PR TITLE
fix: prevent session_index collision in BudgetTracker

### DIFF
--- a/sdk/agentlens/budget.py
+++ b/sdk/agentlens/budget.py
@@ -303,6 +303,13 @@ class BudgetTracker:
         if max_cost_usd is not None and max_cost_usd <= 0:
             raise ValueError("max_cost_usd must be positive")
 
+        if session_id in self._session_index:
+            raise ValueError(
+                f"Session {session_id!r} already has a budget "
+                f"({self._session_index[session_id]}). "
+                f"Remove it first with remove_budget()."
+            )
+
         budget = TokenBudget(
             session_id=session_id,
             agent_name=agent_name,
@@ -460,5 +467,7 @@ class BudgetTracker:
         budget = self._budgets.pop(budget_id, None)
         if budget is None:
             return False
-        self._session_index.pop(budget.session_id, None)
+        # Only remove the session index entry if it still points to this budget
+        if self._session_index.get(budget.session_id) == budget_id:
+            del self._session_index[budget.session_id]
         return True

--- a/sdk/tests/test_budget.py
+++ b/sdk/tests/test_budget.py
@@ -386,3 +386,21 @@ class TestBudgetManagement:
     def test_remove_nonexistent(self):
         tracker = BudgetTracker()
         assert tracker.remove_budget("nope") is False
+
+    def test_duplicate_session_budget_raises(self):
+        """Creating two budgets for the same session_id should raise ValueError."""
+        tracker = BudgetTracker()
+        tracker.create_budget("session-dup", max_tokens=1000)
+        with pytest.raises(ValueError, match="already has a budget"):
+            tracker.create_budget("session-dup", max_tokens=5000)
+
+    def test_remove_budget_does_not_orphan_replacement(self):
+        """After removing a budget, a new one for the same session works correctly."""
+        tracker = BudgetTracker()
+        b1 = tracker.create_budget("session-reuse", max_tokens=1000)
+        tracker.remove_budget(b1.budget_id)
+        # Now creating a new budget for the same session should work
+        b2 = tracker.create_budget("session-reuse", max_tokens=5000)
+        report = tracker.report_for_session("session-reuse")
+        assert report is not None
+        assert report.budget_id == b2.budget_id


### PR DESCRIPTION
Fixes #35

When creating multiple budgets for the same session_id, the second would silently overwrite the first in \_session_index\, making the first budget unreachable via session lookups. Additionally, \emove_budget()\ would incorrectly delete the session_index entry even if it belonged to a different budget.

**Changes:**
- Raise \ValueError\ if a session already has a budget (enforce 1:1 mapping)
- Only remove \_session_index\ entry in \emove_budget()\ if it still points to the budget being removed
- Add tests for duplicate session detection and re-creation after removal