### PR TITLE
fix: support multiple budgets per session in BudgetTracker

### DIFF
--- a/sdk/agentlens/budget.py
+++ b/sdk/agentlens/budget.py
@@ -255,7 +255,7 @@ class BudgetTracker:
 
     def __init__(self) -> None:
         self._budgets: dict[str, TokenBudget] = {}
-        self._session_index: dict[str, str] = {}  # session_id -> budget_id
+        self._session_index: dict[str, list[str]] = {}  # session_id -> [budget_id, ...]
         self._callbacks: list[Callable[[TokenBudget, BudgetStatus], None]] = []
 
     def on_threshold(self, callback: Callable[[TokenBudget, BudgetStatus], None]) -> None:
@@ -313,7 +313,7 @@ class BudgetTracker:
             model=model,
         )
         self._budgets[budget.budget_id] = budget
-        self._session_index[session_id] = budget.budget_id
+        self._session_index.setdefault(session_id, []).append(budget.budget_id)
         return budget
 
     def record(
@@ -396,10 +396,10 @@ class BudgetTracker:
 
         Returns None if no budget exists for this session.
         """
-        budget_id = self._session_index.get(session_id)
-        if budget_id is None:
+        budget_ids = self._session_index.get(session_id)
+        if not budget_ids:
             return None
-        return self.record(budget_id, tokens_in, tokens_out, model, event_id)
+        return self.record(budget_ids[-1], tokens_in, tokens_out, model, event_id)
 
     def report(self, budget_id: str) -> BudgetReport:
         """Generate a snapshot report for a budget.
@@ -441,11 +441,16 @@ class BudgetTracker:
         )
 
     def report_for_session(self, session_id: str) -> BudgetReport | None:
-        """Get report by session ID. Returns None if no budget exists."""
-        budget_id = self._session_index.get(session_id)
-        if budget_id is None:
+        """Get report for the most recent budget by session ID. Returns None if no budget exists."""
+        budget_ids = self._session_index.get(session_id)
+        if not budget_ids:
             return None
-        return self.report(budget_id)
+        return self.report(budget_ids[-1])
+
+    def reports_for_session(self, session_id: str) -> list[BudgetReport]:
+        """Get reports for ALL budgets associated with a session."""
+        budget_ids = self._session_index.get(session_id, [])
+        return [self.report(bid) for bid in budget_ids]
 
     def all_reports(self) -> list[BudgetReport]:
         """Get reports for all registered budgets."""
@@ -460,5 +465,12 @@ class BudgetTracker:
         budget = self._budgets.pop(budget_id, None)
         if budget is None:
             return False
-        self._session_index.pop(budget.session_id, None)
+        budget_ids = self._session_index.get(budget.session_id)
+        if budget_ids is not None:
+            try:
+                budget_ids.remove(budget_id)
+            except ValueError:
+                pass
+            if not budget_ids:
+                del self._session_index[budget.session_id]
         return True

--- a/sdk/tests/test_budget.py
+++ b/sdk/tests/test_budget.py
@@ -386,3 +386,61 @@ class TestBudgetManagement:
     def test_remove_nonexistent(self):
         tracker = BudgetTracker()
         assert tracker.remove_budget("nope") is False
+
+
+# -- Multi-budget sessions -----------------------------------------
+
+
+class TestMultiBudgetSession:
+    """Regression tests for session_index collision (issue #35)."""
+
+    def test_two_budgets_same_session_both_reachable(self):
+        tracker = BudgetTracker()
+        b1 = tracker.create_budget("s1", max_tokens=1000)
+        b2 = tracker.create_budget("s1", max_tokens=5000)
+        # Both budgets exist and are independently accessible
+        assert tracker.get_budget(b1.budget_id) is b1
+        assert tracker.get_budget(b2.budget_id) is b2
+
+    def test_report_for_session_returns_latest(self):
+        tracker = BudgetTracker()
+        b1 = tracker.create_budget("s1", max_tokens=1000)
+        b2 = tracker.create_budget("s1", max_tokens=5000)
+        report = tracker.report_for_session("s1")
+        assert report is not None
+        assert report.budget_id == b2.budget_id
+
+    def test_reports_for_session_returns_all(self):
+        tracker = BudgetTracker()
+        b1 = tracker.create_budget("s1", max_tokens=1000)
+        b2 = tracker.create_budget("s1", max_tokens=5000)
+        reports = tracker.reports_for_session("s1")
+        assert len(reports) == 2
+        assert reports[0].budget_id == b1.budget_id
+        assert reports[1].budget_id == b2.budget_id
+
+    def test_remove_first_budget_does_not_break_second(self):
+        tracker = BudgetTracker()
+        b1 = tracker.create_budget("s1", max_tokens=1000)
+        b2 = tracker.create_budget("s1", max_tokens=5000)
+        tracker.remove_budget(b1.budget_id)
+        # b2 still reachable via session lookup
+        report = tracker.report_for_session("s1")
+        assert report is not None
+        assert report.budget_id == b2.budget_id
+
+    def test_remove_all_budgets_cleans_session_index(self):
+        tracker = BudgetTracker()
+        b1 = tracker.create_budget("s1", max_tokens=1000)
+        b2 = tracker.create_budget("s1", max_tokens=5000)
+        tracker.remove_budget(b1.budget_id)
+        tracker.remove_budget(b2.budget_id)
+        assert tracker.report_for_session("s1") is None
+
+    def test_record_for_session_targets_latest_budget(self):
+        tracker = BudgetTracker()
+        b1 = tracker.create_budget("s1", max_tokens=1000)
+        b2 = tracker.create_budget("s1", max_tokens=5000)
+        tracker.record_for_session("s1", tokens_in=100)
+        assert b1.total_tokens == 0
+        assert b2.total_tokens == 100


### PR DESCRIPTION
## Summary
Changes _session_index from dict[str, str] to dict[str, list[str]] so multiple budgets can coexist for the same session_id.

## Changes
- ecord_for_session and eport_for_session use the **latest** budget for the session
- emove_budget only removes its own entry from the list, preserving other budgets' lookups
- Added ll_reports_for_session() to retrieve reports for all budgets on a session
- 6 new regression tests in TestMultipleBudgetsPerSession

## Testing
All 62 tests pass (56 existing + 6 new).

Fixes #35