### PR TITLE
fix: add authentication and rate limiting to /correlations routes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -48,6 +48,7 @@ app.use("/dependencies", createApiLimiter());
 app.use("/postmortem", createApiLimiter());
 app.use("/bookmarks", createApiLimiter());
 app.use("/baselines", createApiLimiter());
+app.use("/correlations", createApiLimiter());
 
 // ── API key authentication ──────────────────────────────────────────
 const { authenticateApiKey, hasApiKey } = createApiKeyAuth();
@@ -65,6 +66,7 @@ app.use("/dependencies", authenticateApiKey);
 app.use("/bookmarks", authenticateApiKey);
 app.use("/postmortem", authenticateApiKey);
 app.use("/baselines", authenticateApiKey);
+app.use("/correlations", authenticateApiKey);
 
 // Body parser with size limit
 app.use(express.json({ limit: "10mb" }));


### PR DESCRIPTION
Adds missing authenticateApiKey and createApiLimiter() middleware for /correlations routes. All 18 correlation endpoints were previously accessible without authentication.

Fixes #42