### PR TITLE
refactor: extract createLazyStatements factory to eliminate boilerplate

### DIFF
--- a/backend/lib/lazy-statements.js
+++ b/backend/lib/lazy-statements.js
@@ -1,0 +1,41 @@
+"use strict";
+
+/**
+ * Factory for lazy-initialized prepared statement caches.
+ *
+ * Eliminates the repeated pattern found across route files:
+ *
+ *   let _stmts = null;
+ *   function getStatements() {
+ *     if (_stmts) return _stmts;
+ *     const db = getDb();
+ *     _stmts = { ... };
+ *     return _stmts;
+ *   }
+ *
+ * Usage:
+ *   const { createLazyStatements } = require("../lib/lazy-statements");
+ *   const getStatements = createLazyStatements((db) => ({
+ *     listAll: db.prepare("SELECT * FROM foo"),
+ *     insert:  db.prepare("INSERT INTO foo VALUES (?, ?)"),
+ *   }));
+ *
+ *   // In a route handler:
+ *   const stmts = getStatements();
+ *   const rows = stmts.listAll.all();
+ *
+ * @param {(db: import("better-sqlite3").Database) => Object} factory
+ *   Receives the database instance and returns an object of prepared statements.
+ * @returns {() => Object} A getter that lazily initializes and caches the statements.
+ */
+function createLazyStatements(factory) {
+  let cached = null;
+  return function getStatements() {
+    if (cached) return cached;
+    const { getDb } = require("../db");
+    cached = factory(getDb());
+    return cached;
+  };
+}
+
+module.exports = { createLazyStatements };

--- a/backend/routes/bookmarks.js
+++ b/backend/routes/bookmarks.js
@@ -1,46 +1,34 @@
 const express = require("express");
-const { getDb } = require("../db");
 const { requireSessionId, wrapRoute } = require("../lib/request-helpers");
+const { createLazyStatements } = require("../lib/lazy-statements");
 
 const router = express.Router();
 
 // ── Cached prepared statements ──────────────────────────────────────
-// Lazily initialized once per process lifetime. better-sqlite3 prepared
-// statements are reusable, so caching avoids SQL recompilation overhead
-// on every request — consistent with events.js, sessions.js, etc.
-let _bookmarkStmts = null;
-
-function getBookmarkStatements() {
-  if (_bookmarkStmts) return _bookmarkStmts;
-  const db = getDb();
-
-  _bookmarkStmts = {
-    listAll: db.prepare(
-      `SELECT b.session_id, b.note, b.created_at,
-              s.agent_name, s.started_at, s.status,
-              s.total_tokens_in, s.total_tokens_out
-       FROM session_bookmarks b
-       JOIN sessions s ON s.session_id = b.session_id
-       ORDER BY b.created_at DESC`
-    ),
-    getOne: db.prepare(
-      "SELECT session_id, note, created_at FROM session_bookmarks WHERE session_id = ?"
-    ),
-    checkSession: db.prepare(
-      "SELECT session_id FROM sessions WHERE session_id = ?"
-    ),
-    upsert: db.prepare(
-      `INSERT INTO session_bookmarks (session_id, note, created_at)
-       VALUES (?, ?, datetime('now'))
-       ON CONFLICT(session_id) DO UPDATE SET note = excluded.note`
-    ),
-    remove: db.prepare(
-      "DELETE FROM session_bookmarks WHERE session_id = ?"
-    ),
-  };
-
-  return _bookmarkStmts;
-}
+const getBookmarkStatements = createLazyStatements((db) => ({
+  listAll: db.prepare(
+    `SELECT b.session_id, b.note, b.created_at,
+            s.agent_name, s.started_at, s.status,
+            s.total_tokens_in, s.total_tokens_out
+     FROM session_bookmarks b
+     JOIN sessions s ON s.session_id = b.session_id
+     ORDER BY b.created_at DESC`
+  ),
+  getOne: db.prepare(
+    "SELECT session_id, note, created_at FROM session_bookmarks WHERE session_id = ?"
+  ),
+  checkSession: db.prepare(
+    "SELECT session_id FROM sessions WHERE session_id = ?"
+  ),
+  upsert: db.prepare(
+    `INSERT INTO session_bookmarks (session_id, note, created_at)
+     VALUES (?, ?, datetime('now'))
+     ON CONFLICT(session_id) DO UPDATE SET note = excluded.note`
+  ),
+  remove: db.prepare(
+    "DELETE FROM session_bookmarks WHERE session_id = ?"
+  ),
+}));
 
 // ── GET /bookmarks — list all bookmarked sessions ───────────────────
 router.get(

--- a/backend/routes/errors.js
+++ b/backend/routes/errors.js
@@ -1,7 +1,7 @@
 const express = require("express");
-const { getDb } = require("../db");
 const { safeJsonParse } = require("../lib/validation");
 const { parseLimit, wrapRoute } = require("../lib/request-helpers");
+const { createLazyStatements } = require("../lib/lazy-statements");
 
 const router = express.Router();
 
@@ -16,13 +16,7 @@ function toPercent(numerator, denominator) {
 }
 
 // ── Cached prepared statements ──────────────────────────────────────
-let _stmts = null;
-
-function getStatements() {
-  if (_stmts) return _stmts;
-  const db = getDb();
-
-  _stmts = {
+const getStatements = createLazyStatements((db) => ({
     // Overall error summary
     errorSummary: db.prepare(`
       SELECT
@@ -174,10 +168,7 @@ function getStatements() {
       WHERE event_type IN ('error', 'tool_error', 'agent_error')
       ORDER BY timestamp ASC
     `),
-  };
-
-  return _stmts;
-}
+}));
 
 // ── Helper: extract error message from output_data ──────────────────
 function extractErrorMessage(outputData, maxLen = 200) {

--- a/backend/routes/events.js
+++ b/backend/routes/events.js
@@ -11,44 +11,33 @@ const {
   clampNonNegFloat,
 } = require("../lib/validation");
 const { wrapRoute } = require("../lib/request-helpers");
+const { createLazyStatements } = require("../lib/lazy-statements");
 
 const router = express.Router();
 
 // ── Cached prepared statements ──────────────────────────────────────
-// Lazily initialized once per process lifetime instead of per-request.
-// better-sqlite3 prepared statements are reusable and thread-safe within
-// a single Node process, so caching them avoids repeated SQL compilation.
-let _stmts = null;
-
-function getStatements() {
-  if (_stmts) return _stmts;
-  const db = getDb();
-
-  _stmts = {
-    insertSession: db.prepare(`
-      INSERT OR IGNORE INTO sessions (session_id, agent_name, started_at, metadata, status)
-      VALUES (?, ?, ?, ?, ?)
-    `),
-    updateSession: db.prepare(`
-      UPDATE sessions 
-      SET total_tokens_in = total_tokens_in + ?,
-          total_tokens_out = total_tokens_out + ?
-      WHERE session_id = ?
-    `),
-    endSession: db.prepare(`
-      UPDATE sessions SET ended_at = ?, status = ?, 
-        total_tokens_in = CASE WHEN ? > 0 THEN ? ELSE total_tokens_in END,
-        total_tokens_out = CASE WHEN ? > 0 THEN ? ELSE total_tokens_out END
-      WHERE session_id = ?
-    `),
-    insertEvent: db.prepare(`
-      INSERT OR IGNORE INTO events (event_id, session_id, event_type, timestamp, input_data, output_data, model, tokens_in, tokens_out, tool_call, decision_trace, duration_ms)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `),
-  };
-
-  return _stmts;
-}
+const getStatements = createLazyStatements((db) => ({
+  insertSession: db.prepare(`
+    INSERT OR IGNORE INTO sessions (session_id, agent_name, started_at, metadata, status)
+    VALUES (?, ?, ?, ?, ?)
+  `),
+  updateSession: db.prepare(`
+    UPDATE sessions 
+    SET total_tokens_in = total_tokens_in + ?,
+        total_tokens_out = total_tokens_out + ?
+    WHERE session_id = ?
+  `),
+  endSession: db.prepare(`
+    UPDATE sessions SET ended_at = ?, status = ?, 
+      total_tokens_in = CASE WHEN ? > 0 THEN ? ELSE total_tokens_in END,
+      total_tokens_out = CASE WHEN ? > 0 THEN ? ELSE total_tokens_out END
+    WHERE session_id = ?
+  `),
+  insertEvent: db.prepare(`
+    INSERT OR IGNORE INTO events (event_id, session_id, event_type, timestamp, input_data, output_data, model, tokens_in, tokens_out, tool_call, decision_trace, duration_ms)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `),
+}));
 
 // POST /events — Ingest events (batched)
 router.post("/", wrapRoute("ingest events", (req, res) => {

--- a/backend/routes/postmortem.js
+++ b/backend/routes/postmortem.js
@@ -1,37 +1,30 @@
 const express = require("express");
-const { getDb } = require("../db");
 const { isValidSessionId } = require("../lib/validation");
 const { wrapRoute } = require("../lib/request-helpers");
+const { createLazyStatements } = require("../lib/lazy-statements");
 
 const router = express.Router();
 
-let _stmts = null;
-
-function getStatements() {
-  if (_stmts) return _stmts;
-  const db = getDb();
-  _stmts = {
-    sessionEvents: db.prepare(`
-      SELECT event_id, session_id, event_type, timestamp, duration_ms,
-             model, tokens_in, tokens_out, input_data, output_data, tool_call
-      FROM events
-      WHERE session_id = ?
-      ORDER BY timestamp ASC
-    `),
-    recentErrorSessions: db.prepare(`
-      SELECT DISTINCT e.session_id, s.agent_name, s.started_at,
-             COUNT(*) as error_count
-      FROM events e
-      JOIN sessions s ON e.session_id = s.session_id
-      WHERE e.event_type IN ('error', 'tool_error', 'agent_error', 'timeout', 'rate_limit')
-      GROUP BY e.session_id
-      HAVING error_count >= ?
-      ORDER BY s.started_at DESC
-      LIMIT ?
-    `),
-  };
-  return _stmts;
-}
+const getStatements = createLazyStatements((db) => ({
+  sessionEvents: db.prepare(`
+    SELECT event_id, session_id, event_type, timestamp, duration_ms,
+           model, tokens_in, tokens_out, input_data, output_data, tool_call
+    FROM events
+    WHERE session_id = ?
+    ORDER BY timestamp ASC
+  `),
+  recentErrorSessions: db.prepare(`
+    SELECT DISTINCT e.session_id, s.agent_name, s.started_at,
+           COUNT(*) as error_count
+    FROM events e
+    JOIN sessions s ON e.session_id = s.session_id
+    WHERE e.event_type IN ('error', 'tool_error', 'agent_error', 'timeout', 'rate_limit')
+    GROUP BY e.session_id
+    HAVING error_count >= ?
+    ORDER BY s.started_at DESC
+    LIMIT ?
+  `),
+}));
 
 // Default cost rates (per 1K tokens)
 const DEFAULT_COST_INPUT = 0.003;


### PR DESCRIPTION
Introduces lib/lazy-statements.js with a createLazyStatements() factory that eliminates the repeated lazy prepared statement caching pattern found across 12+ route files. Converted 4 files (bookmarks, events, errors, postmortem).
