### PR TITLE
refactor: extract shared ID generation and validation into lib/id-helpers.js

### DIFF
--- a/backend/lib/id-helpers.js
+++ b/backend/lib/id-helpers.js
@@ -1,0 +1,53 @@
+/**
+ * Shared ID generation and validation helpers.
+ *
+ * Consolidates the identical generateId() and RESOURCE_ID_RE patterns
+ * that were duplicated across alerts.js, webhooks.js, and annotations.js.
+ */
+
+const crypto = require("crypto");
+
+// IDs are generated via `Date.now().toString(36)-<12 hex chars>`, so
+// they only contain alphanumeric characters and hyphens.  Reject
+// anything else early to prevent SQL injection or parameter confusion.
+const RESOURCE_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$/;
+
+/**
+ * Generate a unique ID: base-36 timestamp + 6 random bytes (hex).
+ *
+ * @param {string} [prefix] – optional prefix (e.g. "ann") prepended with a hyphen
+ * @returns {string}
+ */
+function generateId(prefix) {
+  const id = `${Date.now().toString(36)}-${crypto.randomBytes(6).toString("hex")}`;
+  return prefix ? `${prefix}-${id}` : id;
+}
+
+/**
+ * Validate a resource ID (alert, webhook, annotation, etc.).
+ *
+ * @param {string} id
+ * @returns {boolean}
+ */
+function isValidResourceId(id) {
+  return typeof id === "string" && RESOURCE_ID_RE.test(id);
+}
+
+/**
+ * Express middleware factory: validate a named path parameter as a resource ID.
+ * Returns 400 if invalid, otherwise calls next().
+ *
+ * @param {string} paramName – the path parameter name to validate
+ * @returns {Function} Express middleware
+ */
+function validateIdParam(paramName) {
+  return (req, res, next) => {
+    const val = req.params[paramName];
+    if (!isValidResourceId(val)) {
+      return res.status(400).json({ error: `Invalid ${paramName} format` });
+    }
+    next();
+  };
+}
+
+module.exports = { generateId, isValidResourceId, validateIdParam, RESOURCE_ID_RE };

--- a/backend/lib/response-cache.js
+++ b/backend/lib/response-cache.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var crypto = require("crypto");
+
 /**
  * In-memory response cache for read-heavy endpoints.
  *
@@ -249,8 +251,15 @@ function cacheMiddleware(cache, options) {
 
     // Include API key hash in cache key to prevent cross-user cache
     // poisoning when multiple API keys have different access levels.
+    // Use a SHA-256 hash of the full key (not a prefix slice) so that
+    // keys sharing the same prefix never collide in the cache.
     var apiKey = req.headers && req.headers["x-api-key"];
-    var keySuffix = apiKey ? "|k:" + apiKey.slice(0, 8) : "|anon";
+    var keySuffix;
+    if (apiKey) {
+      keySuffix = "|k:" + crypto.createHash("sha256").update(String(apiKey)).digest("hex").slice(0, 16);
+    } else {
+      keySuffix = "|anon";
+    }
     var key = (req.originalUrl || req.url) + keySuffix;
     var cached = cache.get(key);
 

--- a/backend/routes/alerts.js
+++ b/backend/routes/alerts.js
@@ -1,27 +1,11 @@
 /* ── Alert Rules — threshold-based alerting for agent observability ──── */
 
 const express = require("express");
-const crypto = require("crypto");
 const router = express.Router();
 const { getDb } = require("../db");
 const { fireWebhooks } = require("./webhooks");
 const { wrapRoute, parseLimit } = require("../lib/request-helpers");
-
-// ── Path parameter validation ───────────────────────────────────────
-// IDs are generated via `Date.now().toString(36)-<12 hex chars>`, so
-// they only contain alphanumeric characters and hyphens.  Reject
-// anything else early to prevent SQL injection or parameter confusion.
-const SAFE_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$/;
-
-function validateIdParam(paramName) {
-  return (req, res, next) => {
-    const val = req.params[paramName];
-    if (!val || !SAFE_ID_RE.test(val)) {
-      return res.status(400).json({ error: `Invalid ${paramName} format` });
-    }
-    next();
-  };
-}
+const { generateId, isValidResourceId } = require("../lib/id-helpers");
 
 // ── Schema initialisation ───────────────────────────────────────────
 
@@ -83,16 +67,7 @@ const MAX_NAME_LENGTH = 128;
 const MAX_AGENT_FILTER_LENGTH = 256;
 const MAX_ALERT_RULES = 100;        // cap total rules to prevent DoS via evaluate endpoint
 
-// Validate ruleId / alertId: alphanumeric + hyphens, max 64 chars.
-// Matches the pattern used by generateId() and prevents log injection
-// or cache pollution from arbitrary-length / special-char params.
-const RESOURCE_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$/;
-
-function isValidResourceId(id) {
-  return typeof id === "string" && RESOURCE_ID_RE.test(id);
-}
-
-// Middleware: reject invalid ruleId early (mirrors webhooks.js pattern)
+// Middleware: reject invalid ruleId/alertId early
 router.param("ruleId", (req, res, next, val) => {
   if (!isValidResourceId(val)) {
     return res.status(400).json({ error: "Invalid rule ID format" });
@@ -106,12 +81,6 @@ router.param("alertId", (req, res, next, val) => {
   }
   next();
 });
-
-// ── Helper: generate unique ID ──────────────────────────────────────
-
-function generateId() {
-  return `${Date.now().toString(36)}-${crypto.randomBytes(6).toString('hex')}`;
-}
 
 // ── Helper: evaluate metric value for a time window ─────────────────
 
@@ -290,7 +259,7 @@ router.post("/rules", wrapRoute("create alert rule", (req, res) => {
 
 // ── PUT /alerts/rules/:ruleId — update an alert rule ────────────────
 
-router.put("/rules/:ruleId", validateIdParam("ruleId"), wrapRoute("update alert rule", (req, res) => {
+router.put("/rules/:ruleId", wrapRoute("update alert rule", (req, res) => {
     ensureAlertsTable();
     const db = getDb();
     const { ruleId } = req.params;
@@ -339,7 +308,7 @@ router.put("/rules/:ruleId", validateIdParam("ruleId"), wrapRoute("update alert 
 
 // ── DELETE /alerts/rules/:ruleId — delete a rule ────────────────────
 
-router.delete("/rules/:ruleId", validateIdParam("ruleId"), wrapRoute("delete alert rule", (req, res) => {
+router.delete("/rules/:ruleId", wrapRoute("delete alert rule", (req, res) => {
     ensureAlertsTable();
     const db = getDb();
     const { ruleId } = req.params;
@@ -462,7 +431,7 @@ router.get("/events", wrapRoute("list alert events", (req, res) => {
 
 // ── PUT /alerts/events/:alertId/acknowledge — ack an alert ──────────
 
-router.put("/events/:alertId/acknowledge", validateIdParam("alertId"), wrapRoute("acknowledge alert", (req, res) => {
+router.put("/events/:alertId/acknowledge", wrapRoute("acknowledge alert", (req, res) => {
     ensureAlertsTable();
     const db = getDb();
     const { alertId } = req.params;

--- a/backend/routes/annotations.js
+++ b/backend/routes/annotations.js
@@ -1,10 +1,10 @@
 /* ── Session Annotations — notes and comments on sessions ──────────── */
 
 const express = require("express");
-const crypto = require("crypto");
 const router = express.Router();
 const { getDb } = require("../db");
 const { parsePagination, wrapRoute } = require("../lib/request-helpers");
+const { generateId } = require("../lib/id-helpers");
 
 // ── Schema initialisation ───────────────────────────────────────────
 
@@ -40,10 +40,10 @@ const VALID_TYPES = ["note", "bug", "insight", "warning", "milestone"];
 const MAX_TEXT_LENGTH = 4000;
 const MAX_AUTHOR_LENGTH = 100;
 
-// ── Helper: generate unique ID ──────────────────────────────────────
+// ── Helper: generate unique annotation ID ───────────────────────────
 
-function generateId() {
-  return `ann-${Date.now().toString(36)}-${crypto.randomBytes(6).toString('hex')}`;
+function generateAnnotationId() {
+  return generateId("ann");
 }
 
 // ── Helper: validate annotation input ───────────────────────────────
@@ -114,7 +114,7 @@ router.post("/:id/annotations", wrapRoute("create annotation", (req, res) => {
   }
 
   const now = new Date().toISOString();
-  const annotationId = generateId();
+  const annotationId = generateAnnotationId();
 
   db.prepare(`
     INSERT INTO annotations

--- a/backend/routes/correlations.js
+++ b/backend/routes/correlations.js
@@ -17,6 +17,7 @@ const router = express.Router();
 const dbMod = require("../db");
 const { wrapRoute, parseLimit, parseOffset } = require("../lib/request-helpers");
 const { sanitizeString, safeJsonParse, safeJsonStringify } = require("../lib/validation");
+const { createLazyStatements } = require("../lib/lazy-statements");
 
 // ── Input limits ────────────────────────────────────────────────────
 const MAX_NAME_LENGTH = 128;
@@ -94,33 +95,96 @@ const CORRELATION_STRATEGIES = {
 
 const VALID_TYPES = Object.keys(CORRELATION_STRATEGIES);
 
+// ── Cached prepared statements for correlation engine ────────────────
+// Previously, runCorrelation() and route handlers called db.prepare()
+// on every request, recompiling SQL each time. This adds ~0.1-0.5ms per
+// call. Since the correlation engine can run hundreds of times (scheduled
+// or batch), caching these statements eliminates redundant compilation.
+
+const getCorrelationStatements = createLazyStatements((db) => ({
+  eventsWithAgent: db.prepare(
+    `SELECT e.*, s.agent_name FROM events e
+     JOIN sessions s ON e.session_id = s.session_id
+     WHERE e.timestamp >= ? AND s.agent_name = ?
+     ORDER BY e.timestamp ASC LIMIT ?`
+  ),
+  eventsAll: db.prepare(
+    `SELECT e.*, s.agent_name FROM events e
+     JOIN sessions s ON e.session_id = s.session_id
+     WHERE e.timestamp >= ?
+     ORDER BY e.timestamp ASC LIMIT ?`
+  ),
+  insertGroup: db.prepare(
+    `INSERT OR IGNORE INTO correlation_groups (group_id, rule_id, label, created_at, metadata)
+     VALUES (?, ?, ?, ?, ?)`
+  ),
+  insertMember: db.prepare(
+    `INSERT OR IGNORE INTO correlation_members (group_id, event_id, session_id, role, added_at)
+     VALUES (?, ?, ?, ?, ?)`
+  ),
+  getRuleById: db.prepare(
+    "SELECT * FROM correlation_rules WHERE rule_id = ?"
+  ),
+  deleteRule: db.prepare(
+    "DELETE FROM correlation_rules WHERE rule_id = ?"
+  ),
+  ruleGroupCount: db.prepare(
+    "SELECT COUNT(*) as group_count FROM correlation_groups WHERE rule_id = ?"
+  ),
+  listRulesAll: db.prepare(
+    "SELECT * FROM correlation_rules ORDER BY priority DESC, created_at DESC"
+  ),
+  listRulesEnabled: db.prepare(
+    "SELECT * FROM correlation_rules WHERE enabled = ? ORDER BY priority DESC, created_at DESC"
+  ),
+  getGroupDetail: db.prepare(
+    `SELECT g.*, r.name as rule_name, r.match_type FROM correlation_groups g
+     JOIN correlation_rules r ON g.rule_id = r.rule_id WHERE g.group_id = ?`
+  ),
+  getGroupMembers: db.prepare(
+    `SELECT m.*, e.event_type, e.timestamp, e.model, e.duration_ms, s.agent_name
+     FROM correlation_members m
+     JOIN events e ON m.event_id = e.event_id
+     JOIN sessions s ON m.session_id = s.session_id
+     WHERE m.group_id = ? ORDER BY e.timestamp ASC`
+  ),
+  deleteGroup: db.prepare(
+    "DELETE FROM correlation_groups WHERE group_id = ?"
+  ),
+  statsRuleCount: db.prepare("SELECT COUNT(*) as cnt FROM correlation_rules"),
+  statsEnabledCount: db.prepare("SELECT COUNT(*) as cnt FROM correlation_rules WHERE enabled = 1"),
+  statsGroupCount: db.prepare("SELECT COUNT(*) as cnt FROM correlation_groups"),
+  statsMemberCount: db.prepare("SELECT COUNT(*) as cnt FROM correlation_members"),
+  statsByType: db.prepare(
+    `SELECT r.match_type, COUNT(g.group_id) as groups FROM correlation_rules r
+     LEFT JOIN correlation_groups g ON r.rule_id = g.rule_id GROUP BY r.match_type`
+  ),
+  eventCorrelations: db.prepare(
+    `SELECT m.group_id, m.role, g.label, g.created_at, g.metadata, r.name as rule_name, r.match_type
+     FROM correlation_members m JOIN correlation_groups g ON m.group_id = g.group_id
+     JOIN correlation_rules r ON g.rule_id = r.rule_id WHERE m.event_id = ? ORDER BY g.created_at DESC`
+  ),
+  groupsCountAll: db.prepare("SELECT COUNT(*) as cnt FROM correlation_groups"),
+  groupsCountByRule: db.prepare("SELECT COUNT(*) as cnt FROM correlation_groups WHERE rule_id = ?"),
+}));
+
 // ── Correlation engine ──────────────────────────────────────────────
 
 const MAX_LOOKBACK_MINUTES = 10080; // 7 days
 const EVENT_CAP = 50000;
 
 function runCorrelation(rule, lookbackMinutes) {
-  const db = dbMod.getDb();
   const config = safeJsonParse(rule.config);
   let lookback = lookbackMinutes || config.lookback_minutes || 60;
   if (lookback > MAX_LOOKBACK_MINUTES) lookback = MAX_LOOKBACK_MINUTES;
   const cutoff = new Date(Date.now() - lookback * 60000).toISOString();
 
+  const stmts = getCorrelationStatements();
   let events;
   if (rule.agent_filter) {
-    events = db.prepare(
-      `SELECT e.*, s.agent_name FROM events e
-       JOIN sessions s ON e.session_id = s.session_id
-       WHERE e.timestamp >= ? AND s.agent_name = ?
-       ORDER BY e.timestamp ASC LIMIT ?`
-    ).all(cutoff, rule.agent_filter, EVENT_CAP);
+    events = stmts.eventsWithAgent.all(cutoff, rule.agent_filter, EVENT_CAP);
   } else {
-    events = db.prepare(
-      `SELECT e.*, s.agent_name FROM events e
-       JOIN sessions s ON e.session_id = s.session_id
-       WHERE e.timestamp >= ?
-       ORDER BY e.timestamp ASC LIMIT ?`
-    ).all(cutoff, EVENT_CAP);
+    events = stmts.eventsAll.all(cutoff, EVENT_CAP);
   }
 
   if (events.length === 0) return [];
@@ -379,14 +443,7 @@ function correlateByCustom(events, config) {
 
 function persistGroups(rule, groups) {
   const db = dbMod.getDb();
-  const insertGroup = db.prepare(
-    `INSERT OR IGNORE INTO correlation_groups (group_id, rule_id, label, created_at, metadata)
-     VALUES (?, ?, ?, ?, ?)`
-  );
-  const insertMember = db.prepare(
-    `INSERT OR IGNORE INTO correlation_members (group_id, event_id, session_id, role, added_at)
-     VALUES (?, ?, ?, ?, ?)`
-  );
+  const stmts = getCorrelationStatements();
 
   const timestamp = now();
   const persisted = [];
@@ -394,10 +451,10 @@ function persistGroups(rule, groups) {
   const txn = db.transaction(() => {
     for (const group of groups) {
       const groupId = uid();
-      insertGroup.run(groupId, rule.rule_id, group.label, timestamp, safeJsonStringify(group.metadata));
+      stmts.insertGroup.run(groupId, rule.rule_id, group.label, timestamp, safeJsonStringify(group.metadata));
       for (let m = 0; m < group.events.length; m++) {
         const evt = group.events[m];
-        insertMember.run(groupId, evt.event_id, evt.session_id, m === 0 ? "origin" : "member", timestamp);
+        stmts.insertMember.run(groupId, evt.event_id, evt.session_id, m === 0 ? "origin" : "member", timestamp);
       }
       persisted.push({ group_id: groupId, label: group.label, member_count: group.events.length });
     }
@@ -456,16 +513,13 @@ router.post("/rules", wrapRoute("create correlation rule", (req, res) => {
 /** GET /rules — List all correlation rules */
 router.get("/rules", wrapRoute("list correlation rules", (req, res) => {
   ensureCorrelationTables();
-  const db = dbMod.getDb();
-  let query = "SELECT * FROM correlation_rules";
-  const params = [];
+  const stmts = getCorrelationStatements();
+  let rules;
   if (req.query.enabled !== undefined) {
-    query += " WHERE enabled = ?";
-    params.push(req.query.enabled === "true" ? 1 : 0);
+    rules = stmts.listRulesEnabled.all(req.query.enabled === "true" ? 1 : 0);
+  } else {
+    rules = stmts.listRulesAll.all();
   }
-  query += " ORDER BY priority DESC, created_at DESC";
-
-  const rules = db.prepare(query).all(...params);
   for (const rule of rules) rule.config = safeJsonParse(rule.config);
   res.json({ rules, total: rules.length });
 }));
@@ -473,11 +527,11 @@ router.get("/rules", wrapRoute("list correlation rules", (req, res) => {
 /** GET /rules/:ruleId — Get a specific rule */
 router.get("/rules/:ruleId", wrapRoute("get correlation rule", (req, res) => {
   ensureCorrelationTables();
-  const db = dbMod.getDb();
-  const rule = db.prepare("SELECT * FROM correlation_rules WHERE rule_id = ?").get(req.params.ruleId);
+  const stmts = getCorrelationStatements();
+  const rule = stmts.getRuleById.get(req.params.ruleId);
   if (!rule) return res.status(404).json({ error: "Rule not found" });
   rule.config = safeJsonParse(rule.config);
-  const stats = db.prepare("SELECT COUNT(*) as group_count FROM correlation_groups WHERE rule_id = ?").get(rule.rule_id);
+  const stats = stmts.ruleGroupCount.get(rule.rule_id);
   rule.group_count = stats.group_count;
   res.json(rule);
 }));
@@ -486,7 +540,8 @@ router.get("/rules/:ruleId", wrapRoute("get correlation rule", (req, res) => {
 router.patch("/rules/:ruleId", wrapRoute("update correlation rule", (req, res) => {
   ensureCorrelationTables();
   const db = dbMod.getDb();
-  const rule = db.prepare("SELECT * FROM correlation_rules WHERE rule_id = ?").get(req.params.ruleId);
+  const stmts = getCorrelationStatements();
+  const rule = stmts.getRuleById.get(req.params.ruleId);
   if (!rule) return res.status(404).json({ error: "Rule not found" });
 
   const fields = [];
@@ -549,8 +604,8 @@ router.patch("/rules/:ruleId", wrapRoute("update correlation rule", (req, res) =
 /** DELETE /rules/:ruleId — Delete a rule (cascades groups) */
 router.delete("/rules/:ruleId", wrapRoute("delete correlation rule", (req, res) => {
   ensureCorrelationTables();
-  const db = dbMod.getDb();
-  const result = db.prepare("DELETE FROM correlation_rules WHERE rule_id = ?").run(req.params.ruleId);
+  const stmts = getCorrelationStatements();
+  const result = stmts.deleteRule.run(req.params.ruleId);
   if (result.changes === 0) return res.status(404).json({ error: "Rule not found" });
   res.json({ deleted: true, rule_id: req.params.ruleId });
 }));
@@ -560,8 +615,8 @@ const MAX_GROUPS_PER_RUN = 500;
 /** POST /rules/:ruleId/run — Execute a correlation rule */
 router.post("/rules/:ruleId/run", wrapRoute("run correlation rule", (req, res) => {
   ensureCorrelationTables();
-  const db = dbMod.getDb();
-  const rule = db.prepare("SELECT * FROM correlation_rules WHERE rule_id = ?").get(req.params.ruleId);
+  const stmts = getCorrelationStatements();
+  const rule = stmts.getRuleById.get(req.params.ruleId);
   if (!rule) return res.status(404).json({ error: "Rule not found" });
 
   let lookback = null;
@@ -635,21 +690,12 @@ router.get("/groups", wrapRoute("list correlation groups", (req, res) => {
 /** GET /groups/:groupId — Get group details with members */
 router.get("/groups/:groupId", wrapRoute("get correlation group", (req, res) => {
   ensureCorrelationTables();
-  const db = dbMod.getDb();
-  const group = db.prepare(
-    `SELECT g.*, r.name as rule_name, r.match_type FROM correlation_groups g
-     JOIN correlation_rules r ON g.rule_id = r.rule_id WHERE g.group_id = ?`
-  ).get(req.params.groupId);
+  const stmts = getCorrelationStatements();
+  const group = stmts.getGroupDetail.get(req.params.groupId);
   if (!group) return res.status(404).json({ error: "Group not found" });
   group.metadata = safeJsonParse(group.metadata);
 
-  const members = db.prepare(
-    `SELECT m.*, e.event_type, e.timestamp, e.model, e.duration_ms, s.agent_name
-     FROM correlation_members m
-     JOIN events e ON m.event_id = e.event_id
-     JOIN sessions s ON m.session_id = s.session_id
-     WHERE m.group_id = ? ORDER BY e.timestamp ASC`
-  ).all(req.params.groupId);
+  const members = stmts.getGroupMembers.all(req.params.groupId);
 
   group.members = members;
   group.member_count = members.length;
@@ -659,8 +705,8 @@ router.get("/groups/:groupId", wrapRoute("get correlation group", (req, res) => 
 /** DELETE /groups/:groupId — Delete a correlation group */
 router.delete("/groups/:groupId", wrapRoute("delete correlation group", (req, res) => {
   ensureCorrelationTables();
-  const db = dbMod.getDb();
-  const result = db.prepare("DELETE FROM correlation_groups WHERE group_id = ?").run(req.params.groupId);
+  const stmts = getCorrelationStatements();
+  const result = stmts.deleteGroup.run(req.params.groupId);
   if (result.changes === 0) return res.status(404).json({ error: "Group not found" });
   res.json({ deleted: true, group_id: req.params.groupId });
 }));
@@ -668,16 +714,12 @@ router.delete("/groups/:groupId", wrapRoute("delete correlation group", (req, re
 /** GET /stats — Correlation statistics */
 router.get("/stats", wrapRoute("correlation stats", (req, res) => {
   ensureCorrelationTables();
-  const db = dbMod.getDb();
-  const ruleCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_rules").get().cnt;
-  const enabledCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_rules WHERE enabled = 1").get().cnt;
-  const groupCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_groups").get().cnt;
-  const memberCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_members").get().cnt;
-
-  const byType = db.prepare(
-    `SELECT r.match_type, COUNT(g.group_id) as groups FROM correlation_rules r
-     LEFT JOIN correlation_groups g ON r.rule_id = g.rule_id GROUP BY r.match_type`
-  ).all();
+  const stmts = getCorrelationStatements();
+  const ruleCount = stmts.statsRuleCount.get().cnt;
+  const enabledCount = stmts.statsEnabledCount.get().cnt;
+  const groupCount = stmts.statsGroupCount.get().cnt;
+  const memberCount = stmts.statsMemberCount.get().cnt;
+  const byType = stmts.statsByType.all();
 
   res.json({
     total_rules: ruleCount, enabled_rules: enabledCount,
@@ -689,12 +731,8 @@ router.get("/stats", wrapRoute("correlation stats", (req, res) => {
 /** GET /event/:eventId — Find all correlations for an event */
 router.get("/event/:eventId", wrapRoute("find event correlations", (req, res) => {
   ensureCorrelationTables();
-  const db = dbMod.getDb();
-  const memberships = db.prepare(
-    `SELECT m.group_id, m.role, g.label, g.created_at, g.metadata, r.name as rule_name, r.match_type
-     FROM correlation_members m JOIN correlation_groups g ON m.group_id = g.group_id
-     JOIN correlation_rules r ON g.rule_id = r.rule_id WHERE m.event_id = ? ORDER BY g.created_at DESC`
-  ).all(req.params.eventId);
+  const stmts = getCorrelationStatements();
+  const memberships = stmts.eventCorrelations.all(req.params.eventId);
   for (const m of memberships) m.metadata = safeJsonParse(m.metadata);
   res.json({ event_id: req.params.eventId, correlations: memberships, total: memberships.length });
 }));

--- a/backend/routes/correlations.js
+++ b/backend/routes/correlations.js
@@ -11,160 +11,169 @@
  * - Track cause-effect chains: agent A output -> agent B input
  * ──────────────────────────────────────────────────────────────────── */
 
-var express = require("express");
-var crypto = require("crypto");
-var router = express.Router();
-var dbMod = require("../db");
-var { wrapRoute, parseLimit, parseOffset } = require("../lib/request-helpers");
-var { sanitizeString, safeJsonParse, safeJsonStringify } = require("../lib/validation");
+const express = require("express");
+const crypto = require("crypto");
+const router = express.Router();
+const dbMod = require("../db");
+const { wrapRoute, parseLimit, parseOffset } = require("../lib/request-helpers");
+const { sanitizeString, safeJsonParse, safeJsonStringify } = require("../lib/validation");
 
 // ── Input limits ────────────────────────────────────────────────────
-var MAX_NAME_LENGTH = 128;
-var MAX_DESCRIPTION_LENGTH = 1024;
-var MAX_CONFIG_SIZE = 8192; // 8 KB serialized config
-var MAX_AGENT_FILTER_LENGTH = 128;
+const MAX_NAME_LENGTH = 128;
+const MAX_DESCRIPTION_LENGTH = 1024;
+const MAX_CONFIG_SIZE = 8192; // 8 KB serialized config
+const MAX_AGENT_FILTER_LENGTH = 128;
 
 // ── Schema ──────────────────────────────────────────────────────────
 
-var _corrReady = false;
+let _corrReady = false;
 function ensureCorrelationTables() {
   if (_corrReady) return;
-  var db = dbMod.getDb();
-  db.exec(
-    "CREATE TABLE IF NOT EXISTS correlation_rules (" +
-    "  rule_id TEXT PRIMARY KEY," +
-    "  name TEXT NOT NULL," +
-    "  description TEXT DEFAULT ''," +
-    "  match_type TEXT NOT NULL," +
-    "  config TEXT NOT NULL DEFAULT '{}'," +
-    "  agent_filter TEXT DEFAULT NULL," +
-    "  enabled INTEGER NOT NULL DEFAULT 1," +
-    "  priority INTEGER NOT NULL DEFAULT 0," +
-    "  created_at TEXT NOT NULL," +
-    "  updated_at TEXT NOT NULL" +
-    ");" +
-    "CREATE TABLE IF NOT EXISTS correlation_groups (" +
-    "  group_id TEXT PRIMARY KEY," +
-    "  rule_id TEXT NOT NULL," +
-    "  label TEXT DEFAULT ''," +
-    "  created_at TEXT NOT NULL," +
-    "  metadata TEXT DEFAULT '{}'," +
-    "  FOREIGN KEY (rule_id) REFERENCES correlation_rules(rule_id) ON DELETE CASCADE" +
-    ");" +
-    "CREATE TABLE IF NOT EXISTS correlation_members (" +
-    "  group_id TEXT NOT NULL," +
-    "  event_id TEXT NOT NULL," +
-    "  session_id TEXT NOT NULL," +
-    "  role TEXT DEFAULT 'member'," +
-    "  added_at TEXT NOT NULL," +
-    "  PRIMARY KEY (group_id, event_id)," +
-    "  FOREIGN KEY (group_id) REFERENCES correlation_groups(group_id) ON DELETE CASCADE" +
-    ");" +
-    "CREATE INDEX IF NOT EXISTS idx_corr_groups_rule ON correlation_groups(rule_id);" +
-    "CREATE INDEX IF NOT EXISTS idx_corr_members_event ON correlation_members(event_id);" +
-    "CREATE INDEX IF NOT EXISTS idx_corr_members_session ON correlation_members(session_id);" +
-    "CREATE INDEX IF NOT EXISTS idx_corr_rules_enabled ON correlation_rules(enabled);"
-  );
+  const db = dbMod.getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS correlation_rules (
+      rule_id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT DEFAULT '',
+      match_type TEXT NOT NULL,
+      config TEXT NOT NULL DEFAULT '{}',
+      agent_filter TEXT DEFAULT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      priority INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS correlation_groups (
+      group_id TEXT PRIMARY KEY,
+      rule_id TEXT NOT NULL,
+      label TEXT DEFAULT '',
+      created_at TEXT NOT NULL,
+      metadata TEXT DEFAULT '{}',
+      FOREIGN KEY (rule_id) REFERENCES correlation_rules(rule_id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS correlation_members (
+      group_id TEXT NOT NULL,
+      event_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      role TEXT DEFAULT 'member',
+      added_at TEXT NOT NULL,
+      PRIMARY KEY (group_id, event_id),
+      FOREIGN KEY (group_id) REFERENCES correlation_groups(group_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_corr_groups_rule ON correlation_groups(rule_id);
+    CREATE INDEX IF NOT EXISTS idx_corr_members_event ON correlation_members(event_id);
+    CREATE INDEX IF NOT EXISTS idx_corr_members_session ON correlation_members(session_id);
+    CREATE INDEX IF NOT EXISTS idx_corr_rules_enabled ON correlation_rules(enabled);
+  `);
   _corrReady = true;
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-function now() { return new Date().toISOString(); }
-function uid() { return crypto.randomUUID(); }
+const now = () => new Date().toISOString();
+const uid = () => crypto.randomUUID();
+
+/** Pre-compute _ts on each event to avoid repeated Date parsing in hot loops. */
+function ensureTimestamps(events) {
+  for (let i = 0; i < events.length; i++) {
+    if (events[i]._ts === undefined) {
+      events[i]._ts = new Date(events[i].timestamp).getTime();
+    }
+  }
+}
+
+// ── Correlation strategy registry ───────────────────────────────────
+
+const CORRELATION_STRATEGIES = {
+  metadata_key:  correlateByMetadata,
+  time_window:   correlateByTimeWindow,
+  error_cascade: correlateByErrorCascade,
+  causal_chain:  correlateByCausalChain,
+  custom:        correlateByCustom,
+};
+
+const VALID_TYPES = Object.keys(CORRELATION_STRATEGIES);
 
 // ── Correlation engine ──────────────────────────────────────────────
 
-function runCorrelation(rule, lookbackMinutes) {
-  var db = dbMod.getDb();
-  var config = safeJsonParse(rule.config);
-  var lookback = lookbackMinutes || config.lookback_minutes || 60;
-  // Cap lookback to prevent full-table scans (max 7 days = 10080 min)
-  var MAX_LOOKBACK_MINUTES = 10080;
-  if (lookback > MAX_LOOKBACK_MINUTES) lookback = MAX_LOOKBACK_MINUTES;
-  var cutoff = new Date(Date.now() - lookback * 60000).toISOString();
+const MAX_LOOKBACK_MINUTES = 10080; // 7 days
+const EVENT_CAP = 50000;
 
-  // Cap loaded events to prevent OOM on large datasets
-  var EVENT_CAP = 50000;
-  var events;
+function runCorrelation(rule, lookbackMinutes) {
+  const db = dbMod.getDb();
+  const config = safeJsonParse(rule.config);
+  let lookback = lookbackMinutes || config.lookback_minutes || 60;
+  if (lookback > MAX_LOOKBACK_MINUTES) lookback = MAX_LOOKBACK_MINUTES;
+  const cutoff = new Date(Date.now() - lookback * 60000).toISOString();
+
+  let events;
   if (rule.agent_filter) {
     events = db.prepare(
-      "SELECT e.*, s.agent_name FROM events e " +
-      "JOIN sessions s ON e.session_id = s.session_id " +
-      "WHERE e.timestamp >= ? AND s.agent_name = ? " +
-      "ORDER BY e.timestamp ASC LIMIT ?"
+      `SELECT e.*, s.agent_name FROM events e
+       JOIN sessions s ON e.session_id = s.session_id
+       WHERE e.timestamp >= ? AND s.agent_name = ?
+       ORDER BY e.timestamp ASC LIMIT ?`
     ).all(cutoff, rule.agent_filter, EVENT_CAP);
   } else {
     events = db.prepare(
-      "SELECT e.*, s.agent_name FROM events e " +
-      "JOIN sessions s ON e.session_id = s.session_id " +
-      "WHERE e.timestamp >= ? " +
-      "ORDER BY e.timestamp ASC LIMIT ?"
+      `SELECT e.*, s.agent_name FROM events e
+       JOIN sessions s ON e.session_id = s.session_id
+       WHERE e.timestamp >= ?
+       ORDER BY e.timestamp ASC LIMIT ?`
     ).all(cutoff, EVENT_CAP);
   }
 
   if (events.length === 0) return [];
 
-  // Pre-compute timestamps once to avoid repeated Date parsing in hot loops
-  for (var p = 0; p < events.length; p++) {
-    events[p]._ts = new Date(events[p].timestamp).getTime();
-  }
+  ensureTimestamps(events);
 
-  switch (rule.match_type) {
-    case "metadata_key":   return correlateByMetadata(events, config);
-    case "time_window":    return correlateByTimeWindow(events, config);
-    case "error_cascade":  return correlateByErrorCascade(events, config);
-    case "causal_chain":   return correlateByCausalChain(events, config);
-    case "custom":         return correlateByCustom(events, config);
-    default:               return [];
-  }
+  const strategy = CORRELATION_STRATEGIES[rule.match_type];
+  return strategy ? strategy(events, config) : [];
 }
 
 /** Group events that share the same value for a metadata key. */
 function correlateByMetadata(events, config) {
-  var key = config.key;
+  const key = config.key;
   if (!key) return [];
 
-  var groups = {};
-  var fields = ["input_data", "output_data", "decision_trace"];
-  // Cache parsed JSON per event to avoid re-parsing the same blob
-  // across multiple correlation runs in a single request.
-  // Capped to prevent memory exhaustion when events carry many unique blobs.
-  var PARSE_CACHE_MAX = 10000;
-  var parseCache = new Map();
-  for (var i = 0; i < events.length; i++) {
-    var evt = events[i];
-    var val = undefined;
-    for (var f = 0; f < fields.length; f++) {
+  const groups = {};
+  const fields = ["input_data", "output_data", "decision_trace"];
+  const PARSE_CACHE_MAX = 10000;
+  const parseCache = new Map();
+
+  for (const evt of events) {
+    let val;
+    for (const field of fields) {
       if (val !== undefined) break;
-      var raw = evt[fields[f]];
+      const raw = evt[field];
       if (!raw) continue;
-      var parsed;
+
+      let parsed;
       if (parseCache.has(raw)) {
         parsed = parseCache.get(raw);
       } else {
-        try { parsed = JSON.parse(raw); } catch (e) { parsed = null; }
+        try { parsed = JSON.parse(raw); } catch { parsed = null; }
         if (parseCache.size < PARSE_CACHE_MAX) {
           parseCache.set(raw, parsed);
         }
       }
       if (parsed && parsed[key] !== undefined) val = parsed[key];
     }
+
     if (val !== undefined && val !== null && val !== "") {
-      var strVal = String(val);
+      const strVal = String(val);
       if (!groups[strVal]) groups[strVal] = [];
       groups[strVal].push(evt);
     }
   }
 
-  var result = [];
-  var keys = Object.keys(groups);
-  for (var k = 0; k < keys.length; k++) {
-    if (groups[keys[k]].length >= 2) {
+  const result = [];
+  for (const [groupKey, groupEvents] of Object.entries(groups)) {
+    if (groupEvents.length >= 2) {
       result.push({
-        label: key + "=" + keys[k],
-        events: groups[keys[k]],
-        metadata: { key: key, value: keys[k] },
+        label: `${key}=${groupKey}`,
+        events: groupEvents,
+        metadata: { key, value: groupKey },
       });
     }
   }
@@ -173,52 +182,41 @@ function correlateByMetadata(events, config) {
 
 /** Group events occurring within a sliding time window. */
 function correlateByTimeWindow(events, config) {
-  var windowMs = (config.window_seconds || 10) * 1000;
-  var minEvents = config.min_events || 2;
-  var typeFilter = config.event_type_filter || null;
+  const windowMs = (config.window_seconds || 10) * 1000;
+  const minEvents = config.min_events || 2;
+  const typeFilter = config.event_type_filter || null;
 
-  var filtered = events;
+  let filtered = events;
   if (typeFilter) {
-    filtered = [];
-    for (var f = 0; f < events.length; f++) {
-      if (events[f].event_type === typeFilter) filtered.push(events[f]);
-    }
+    filtered = events.filter(e => e.event_type === typeFilter);
   }
   if (filtered.length < minEvents) return [];
 
-  // Ensure _ts is populated
-  for (var t = 0; t < filtered.length; t++) {
-    if (filtered[t]._ts === undefined) filtered[t]._ts = new Date(filtered[t].timestamp).getTime();
-  }
+  ensureTimestamps(filtered);
 
-  var groups = [];
-  var i = 0;
+  const groups = [];
+  let i = 0;
   while (i < filtered.length) {
-    var windowStart = filtered[i]._ts;
-    var windowEnd = windowStart + windowMs;
-    var group = [filtered[i]];
-    var j = i + 1;
-    while (j < filtered.length) {
-      if (filtered[j]._ts <= windowEnd) { group.push(filtered[j]); j++; }
-      else break;
+    const windowStart = filtered[i]._ts;
+    const windowEnd = windowStart + windowMs;
+    const group = [filtered[i]];
+    let j = i + 1;
+    while (j < filtered.length && filtered[j]._ts <= windowEnd) {
+      group.push(filtered[j]);
+      j++;
     }
     if (group.length >= minEvents) {
-      var sessionSet = {};
-      var sessionCount = 0;
-      for (var s = 0; s < group.length; s++) {
-        if (!sessionSet[group[s].session_id]) {
-          sessionSet[group[s].session_id] = true;
-          sessionCount++;
-        }
-      }
-      if (sessionCount >= 2 || !config.require_cross_session) {
+      const sessionSet = new Set();
+      for (const evt of group) sessionSet.add(evt.session_id);
+
+      if (sessionSet.size >= 2 || !config.require_cross_session) {
         groups.push({
-          label: "window@" + filtered[i].timestamp,
+          label: `window@${filtered[i].timestamp}`,
           events: group,
           metadata: {
             window_start: filtered[i].timestamp,
             window_seconds: config.window_seconds || 10,
-            session_count: sessionCount,
+            session_count: sessionSet.size,
           },
         });
       }
@@ -228,51 +226,41 @@ function correlateByTimeWindow(events, config) {
   return groups;
 }
 
+const ERROR_EVENT_TYPES = new Set(["error", "agent_error", "tool_error"]);
+
 /** Find error cascades: errors in one agent followed by errors in another. */
 function correlateByErrorCascade(events, config) {
-  var windowMs = (config.cascade_window_seconds || 30) * 1000;
-  var errors = [];
-  for (var e = 0; e < events.length; e++) {
-    if (events[e]._ts === undefined) events[e]._ts = new Date(events[e].timestamp).getTime();
-    if (events[e].event_type === "error" || events[e].event_type === "agent_error" || events[e].event_type === "tool_error") {
-      errors.push(events[e]);
-    }
-  }
+  const windowMs = (config.cascade_window_seconds || 30) * 1000;
+
+  ensureTimestamps(events);
+  const errors = events.filter(e => ERROR_EVENT_TYPES.has(e.event_type));
   if (errors.length < 2) return [];
 
-  var groups = [];
-  var used = {};
+  const groups = [];
+  const used = new Set();
 
-  for (var i = 0; i < errors.length; i++) {
-    if (used[errors[i].event_id]) continue;
-    var cascade = [errors[i]];
-    var startTs = errors[i]._ts;
-    var sourceAgent = errors[i].agent_name;
+  for (let i = 0; i < errors.length; i++) {
+    if (used.has(errors[i].event_id)) continue;
+    const cascade = [errors[i]];
+    const startTs = errors[i]._ts;
+    const sourceAgent = errors[i].agent_name;
 
-    for (var j = i + 1; j < errors.length; j++) {
-      if (used[errors[j].event_id]) continue;
+    for (let j = i + 1; j < errors.length; j++) {
+      if (used.has(errors[j].event_id)) continue;
       if (errors[j]._ts - startTs > windowMs) break;
       if (errors[j].agent_name !== sourceAgent) {
         cascade.push(errors[j]);
-        used[errors[j].event_id] = true;
+        used.add(errors[j].event_id);
       }
     }
+
     if (cascade.length >= 2) {
-      used[errors[i].event_id] = true;
-      var agentsSeen = {};
-      var agents = [];
-      for (var a = 0; a < cascade.length; a++) {
-        if (!agentsSeen[cascade[a].agent_name]) {
-          agentsSeen[cascade[a].agent_name] = true;
-          agents.push(cascade[a].agent_name);
-        }
-      }
-      var affected = [];
-      for (var af = 0; af < agents.length; af++) {
-        if (agents[af] !== sourceAgent) affected.push(agents[af]);
-      }
+      used.add(errors[i].event_id);
+      const agents = [...new Set(cascade.map(e => e.agent_name))];
+      const affected = agents.filter(a => a !== sourceAgent);
+
       groups.push({
-        label: "cascade:" + agents.join("\u2192"),
+        label: `cascade:${agents.join("\u2192")}`,
         events: cascade,
         metadata: {
           source_agent: sourceAgent,
@@ -286,40 +274,36 @@ function correlateByErrorCascade(events, config) {
 }
 
 /** Find causal chains: output of one event matches input of another.
- *  Optimized: build an inverted index from input_data tokens to avoid O(n²) string scans. */
+ *  Uses an inverted index from input_data tokens to avoid O(n²) string scans. */
 function correlateByCausalChain(events, config) {
-  var maxGapMs = (config.max_gap_seconds || 60) * 1000;
-  var matchFields = config.match_fields || ["output_data"];
-  var groups = [];
+  const maxGapMs = (config.max_gap_seconds || 60) * 1000;
+  const matchFields = config.match_fields || ["output_data"];
+  const groups = [];
 
-  // Build index: for each event with input_data, map its value to the event
-  // for fast lookup instead of scanning all subsequent events.
-  // Only index input_data values up to 4 KB to prevent a single request
-  // from allocating hundreds of MB when events carry large payloads.
-  var INPUT_INDEX_MAX_VALUE_LEN = 4096;
-  var inputIndex = {}; // input_data string -> [{ evt, idx }]
-  for (var idx = 0; idx < events.length; idx++) {
-    var inputVal = events[idx].input_data;
+  // Build index: map input_data values to events for fast lookup.
+  // Only index values up to 4 KB to prevent memory exhaustion.
+  const INPUT_INDEX_MAX_VALUE_LEN = 4096;
+  const inputIndex = {};
+  for (let idx = 0; idx < events.length; idx++) {
+    const inputVal = events[idx].input_data;
     if (inputVal && inputVal.length <= INPUT_INDEX_MAX_VALUE_LEN) {
       if (!inputIndex[inputVal]) inputIndex[inputVal] = [];
-      inputIndex[inputVal].push({ evt: events[idx], idx: idx });
+      inputIndex[inputVal].push({ evt: events[idx], idx });
     }
   }
 
-  for (var i = 0; i < events.length; i++) {
-    var chain = [events[i]];
-    var ts1 = events[i]._ts;
+  for (let i = 0; i < events.length; i++) {
+    const chain = [events[i]];
+    const ts1 = events[i]._ts;
 
-    // For each match field, check if any later event's input_data contains this value
-    for (var k = 0; k < matchFields.length; k++) {
-      var val1 = events[i][matchFields[k]] || "";
+    for (const field of matchFields) {
+      const val1 = events[i][field] || "";
       if (!val1) continue;
 
       // Fast path: exact match via index
-      var candidates = inputIndex[val1];
+      const candidates = inputIndex[val1];
       if (candidates) {
-        for (var c = 0; c < candidates.length; c++) {
-          var cand = candidates[c];
+        for (const cand of candidates) {
           if (cand.idx <= i) continue;
           if (cand.evt._ts - ts1 > maxGapMs) continue;
           if (cand.evt.session_id === events[i].session_id) continue;
@@ -329,10 +313,10 @@ function correlateByCausalChain(events, config) {
 
       // Slow path for substring matches (only if no exact matches found)
       if (chain.length < 2) {
-        for (var j = i + 1; j < events.length; j++) {
+        for (let j = i + 1; j < events.length; j++) {
           if (events[j]._ts - ts1 > maxGapMs) break;
           if (events[j].session_id === events[i].session_id) continue;
-          var val2 = events[j].input_data || "";
+          const val2 = events[j].input_data || "";
           if (val2 && val2 !== val1 && val2.indexOf(val1) >= 0) {
             chain.push(events[j]);
           }
@@ -342,7 +326,7 @@ function correlateByCausalChain(events, config) {
 
     if (chain.length >= 2) {
       groups.push({
-        label: "chain:" + (events[i].agent_name || "?") + "\u2192" + (chain[chain.length - 1].agent_name || "?"),
+        label: `chain:${events[i].agent_name || "?"}\u2192${chain[chain.length - 1].agent_name || "?"}`,
         events: chain,
         metadata: { match_fields: matchFields, chain_length: chain.length },
       });
@@ -353,33 +337,31 @@ function correlateByCausalChain(events, config) {
 
 /** Custom correlation by event_type and metadata pattern match. */
 function correlateByCustom(events, config) {
-  var types = config.event_types || [];
-  var groupBy = config.group_by;
+  const types = config.event_types || [];
 
-  var filtered = events;
+  let filtered = events;
   if (types.length > 0) {
-    filtered = [];
-    for (var i = 0; i < events.length; i++) {
-      if (types.indexOf(events[i].event_type) >= 0) filtered.push(events[i]);
-    }
+    const typeSet = new Set(types);
+    filtered = events.filter(e => typeSet.has(e.event_type));
   }
   if (filtered.length < 2) return [];
 
+  const groupBy = config.group_by;
   if (groupBy) {
-    var buckets = {};
-    for (var b = 0; b < filtered.length; b++) {
-      var val = filtered[b][groupBy] || "unknown";
+    const buckets = {};
+    for (const evt of filtered) {
+      const val = evt[groupBy] || "unknown";
       if (!buckets[val]) buckets[val] = [];
-      buckets[val].push(filtered[b]);
+      buckets[val].push(evt);
     }
-    var result = [];
-    var bkeys = Object.keys(buckets);
-    for (var bk = 0; bk < bkeys.length; bk++) {
-      if (buckets[bkeys[bk]].length >= 2) {
+
+    const result = [];
+    for (const [key, bucket] of Object.entries(buckets)) {
+      if (bucket.length >= 2) {
         result.push({
-          label: groupBy + "=" + bkeys[bk],
-          events: buckets[bkeys[bk]],
-          metadata: { group_by: groupBy, value: bkeys[bk] },
+          label: `${groupBy}=${key}`,
+          events: bucket,
+          metadata: { group_by: groupBy, value: key },
         });
       }
     }
@@ -387,7 +369,7 @@ function correlateByCustom(events, config) {
   }
 
   return [{
-    label: "custom:" + types.join("+"),
+    label: `custom:${types.join("+")}`,
     events: filtered,
     metadata: { event_types: types },
   }];
@@ -396,28 +378,28 @@ function correlateByCustom(events, config) {
 // ── Persist correlation results ─────────────────────────────────────
 
 function persistGroups(rule, groups) {
-  var db = dbMod.getDb();
-  var insertGroup = db.prepare(
-    "INSERT OR IGNORE INTO correlation_groups (group_id, rule_id, label, created_at, metadata) " +
-    "VALUES (?, ?, ?, ?, ?)"
+  const db = dbMod.getDb();
+  const insertGroup = db.prepare(
+    `INSERT OR IGNORE INTO correlation_groups (group_id, rule_id, label, created_at, metadata)
+     VALUES (?, ?, ?, ?, ?)`
   );
-  var insertMember = db.prepare(
-    "INSERT OR IGNORE INTO correlation_members (group_id, event_id, session_id, role, added_at) " +
-    "VALUES (?, ?, ?, ?, ?)"
+  const insertMember = db.prepare(
+    `INSERT OR IGNORE INTO correlation_members (group_id, event_id, session_id, role, added_at)
+     VALUES (?, ?, ?, ?, ?)`
   );
 
-  var timestamp = now();
-  var persisted = [];
+  const timestamp = now();
+  const persisted = [];
 
-  var txn = db.transaction(function() {
-    for (var g = 0; g < groups.length; g++) {
-      var groupId = uid();
-      insertGroup.run(groupId, rule.rule_id, groups[g].label, timestamp, safeJsonStringify(groups[g].metadata));
-      for (var m = 0; m < groups[g].events.length; m++) {
-        var evt = groups[g].events[m];
+  const txn = db.transaction(() => {
+    for (const group of groups) {
+      const groupId = uid();
+      insertGroup.run(groupId, rule.rule_id, group.label, timestamp, safeJsonStringify(group.metadata));
+      for (let m = 0; m < group.events.length; m++) {
+        const evt = group.events[m];
         insertMember.run(groupId, evt.event_id, evt.session_id, m === 0 ? "origin" : "member", timestamp);
       }
-      persisted.push({ group_id: groupId, label: groups[g].label, member_count: groups[g].events.length });
+      persisted.push({ group_id: groupId, label: group.label, member_count: group.events.length });
     }
   });
   txn();
@@ -427,13 +409,11 @@ function persistGroups(rule, groups) {
 
 // ── Routes ──────────────────────────────────────────────────────────
 
-var VALID_TYPES = ["metadata_key", "time_window", "error_cascade", "causal_chain", "custom"];
-
 /** POST /rules — Create a correlation rule */
-router.post("/rules", wrapRoute("create correlation rule", function(req, res) {
+router.post("/rules", wrapRoute("create correlation rule", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var body = req.body;
+  const db = dbMod.getDb();
+  const { body } = req;
 
   if (!body.name || typeof body.name !== "string" || !body.name.trim()) {
     return res.status(400).json({ error: "name is required and must be a non-empty string" });
@@ -441,81 +421,77 @@ router.post("/rules", wrapRoute("create correlation rule", function(req, res) {
   if (!body.match_type) {
     return res.status(400).json({ error: "match_type is required" });
   }
-  if (VALID_TYPES.indexOf(body.match_type) < 0) {
-    return res.status(400).json({ error: "match_type must be one of: " + VALID_TYPES.join(", ") });
+  if (!CORRELATION_STRATEGIES[body.match_type]) {
+    return res.status(400).json({ error: `match_type must be one of: ${VALID_TYPES.join(", ")}` });
   }
 
-  var safeName = sanitizeString(body.name, MAX_NAME_LENGTH) || "unnamed";
-  var safeDesc = sanitizeString(body.description || "", MAX_DESCRIPTION_LENGTH) || "";
-  var safeAgentFilter = body.agent_filter
+  const safeName = sanitizeString(body.name, MAX_NAME_LENGTH) || "unnamed";
+  const safeDesc = sanitizeString(body.description || "", MAX_DESCRIPTION_LENGTH) || "";
+  const safeAgentFilter = body.agent_filter
     ? sanitizeString(body.agent_filter, MAX_AGENT_FILTER_LENGTH)
     : null;
 
-  // Validate config size to prevent resource exhaustion
-  var configStr = safeJsonStringify(body.config);
+  const configStr = safeJsonStringify(body.config);
   if (configStr.length > MAX_CONFIG_SIZE) {
-    return res.status(400).json({ error: "config is too large (max " + MAX_CONFIG_SIZE + " bytes)" });
+    return res.status(400).json({ error: `config is too large (max ${MAX_CONFIG_SIZE} bytes)` });
   }
 
-  // Validate priority is a bounded integer
-  var priority = 0;
+  let priority = 0;
   if (body.priority !== undefined) {
     priority = parseInt(body.priority);
     if (!Number.isFinite(priority)) priority = 0;
     priority = Math.max(-100, Math.min(100, priority));
   }
 
-  var ruleId = uid();
-  var timestamp = now();
+  const ruleId = uid();
+  const timestamp = now();
   db.prepare(
-    "INSERT INTO correlation_rules (rule_id, name, description, match_type, config, agent_filter, priority, created_at, updated_at) " +
-    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    `INSERT INTO correlation_rules (rule_id, name, description, match_type, config, agent_filter, priority, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(ruleId, safeName, safeDesc, body.match_type, configStr, safeAgentFilter, priority, timestamp, timestamp);
 
   res.status(201).json({ rule_id: ruleId, name: safeName, match_type: body.match_type, created_at: timestamp });
 }));
 
 /** GET /rules — List all correlation rules */
-router.get("/rules", wrapRoute("list correlation rules", function(req, res) {
+router.get("/rules", wrapRoute("list correlation rules", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var query = "SELECT * FROM correlation_rules";
-  var params = [];
+  const db = dbMod.getDb();
+  let query = "SELECT * FROM correlation_rules";
+  const params = [];
   if (req.query.enabled !== undefined) {
     query += " WHERE enabled = ?";
     params.push(req.query.enabled === "true" ? 1 : 0);
   }
   query += " ORDER BY priority DESC, created_at DESC";
 
-  var stmt = db.prepare(query);
-  var rules = params.length > 0 ? stmt.all(params[0]) : stmt.all();
-  for (var i = 0; i < rules.length; i++) { rules[i].config = safeJsonParse(rules[i].config); }
-  res.json({ rules: rules, total: rules.length });
+  const rules = db.prepare(query).all(...params);
+  for (const rule of rules) rule.config = safeJsonParse(rule.config);
+  res.json({ rules, total: rules.length });
 }));
 
 /** GET /rules/:ruleId — Get a specific rule */
-router.get("/rules/:ruleId", wrapRoute("get correlation rule", function(req, res) {
+router.get("/rules/:ruleId", wrapRoute("get correlation rule", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var rule = db.prepare("SELECT * FROM correlation_rules WHERE rule_id = ?").get(req.params.ruleId);
+  const db = dbMod.getDb();
+  const rule = db.prepare("SELECT * FROM correlation_rules WHERE rule_id = ?").get(req.params.ruleId);
   if (!rule) return res.status(404).json({ error: "Rule not found" });
   rule.config = safeJsonParse(rule.config);
-  var stats = db.prepare("SELECT COUNT(*) as group_count FROM correlation_groups WHERE rule_id = ?").get(rule.rule_id);
+  const stats = db.prepare("SELECT COUNT(*) as group_count FROM correlation_groups WHERE rule_id = ?").get(rule.rule_id);
   rule.group_count = stats.group_count;
   res.json(rule);
 }));
 
 /** PATCH /rules/:ruleId — Update a rule */
-router.patch("/rules/:ruleId", wrapRoute("update correlation rule", function(req, res) {
+router.patch("/rules/:ruleId", wrapRoute("update correlation rule", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var rule = db.prepare("SELECT * FROM correlation_rules WHERE rule_id = ?").get(req.params.ruleId);
+  const db = dbMod.getDb();
+  const rule = db.prepare("SELECT * FROM correlation_rules WHERE rule_id = ?").get(req.params.ruleId);
   if (!rule) return res.status(404).json({ error: "Rule not found" });
 
-  var fields = [];
-  var values = [];
+  const fields = [];
+  const values = [];
 
-  // Validate and sanitize each allowed field
   if (req.body.name !== undefined) {
     if (typeof req.body.name !== "string" || !req.body.name.trim()) {
       return res.status(400).json({ error: "name must be a non-empty string" });
@@ -528,16 +504,16 @@ router.patch("/rules/:ruleId", wrapRoute("update correlation rule", function(req
     values.push(sanitizeString(req.body.description || "", MAX_DESCRIPTION_LENGTH) || "");
   }
   if (req.body.match_type !== undefined) {
-    if (VALID_TYPES.indexOf(req.body.match_type) < 0) {
-      return res.status(400).json({ error: "match_type must be one of: " + VALID_TYPES.join(", ") });
+    if (!CORRELATION_STRATEGIES[req.body.match_type]) {
+      return res.status(400).json({ error: `match_type must be one of: ${VALID_TYPES.join(", ")}` });
     }
     fields.push("match_type = ?");
     values.push(req.body.match_type);
   }
   if (req.body.config !== undefined) {
-    var configStr = safeJsonStringify(req.body.config);
+    const configStr = safeJsonStringify(req.body.config);
     if (configStr.length > MAX_CONFIG_SIZE) {
-      return res.status(400).json({ error: "config is too large (max " + MAX_CONFIG_SIZE + " bytes)" });
+      return res.status(400).json({ error: `config is too large (max ${MAX_CONFIG_SIZE} bytes)` });
     }
     fields.push("config = ?");
     values.push(configStr);
@@ -553,7 +529,7 @@ router.patch("/rules/:ruleId", wrapRoute("update correlation rule", function(req
     values.push(req.body.enabled ? 1 : 0);
   }
   if (req.body.priority !== undefined) {
-    var priority = parseInt(req.body.priority);
+    let priority = parseInt(req.body.priority);
     if (!Number.isFinite(priority)) {
       return res.status(400).json({ error: "priority must be an integer" });
     }
@@ -566,57 +542,50 @@ router.patch("/rules/:ruleId", wrapRoute("update correlation rule", function(req
   fields.push("updated_at = ?");
   values.push(now());
   values.push(req.params.ruleId);
-  var updateStmt = db.prepare("UPDATE correlation_rules SET " + fields.join(", ") + " WHERE rule_id = ?");
-  updateStmt.run.apply(updateStmt, values);
+  db.prepare(`UPDATE correlation_rules SET ${fields.join(", ")} WHERE rule_id = ?`).run(...values);
   res.json({ updated: true, rule_id: req.params.ruleId });
 }));
 
 /** DELETE /rules/:ruleId — Delete a rule (cascades groups) */
-router.delete("/rules/:ruleId", wrapRoute("delete correlation rule", function(req, res) {
+router.delete("/rules/:ruleId", wrapRoute("delete correlation rule", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var result = db.prepare("DELETE FROM correlation_rules WHERE rule_id = ?").run(req.params.ruleId);
+  const db = dbMod.getDb();
+  const result = db.prepare("DELETE FROM correlation_rules WHERE rule_id = ?").run(req.params.ruleId);
   if (result.changes === 0) return res.status(404).json({ error: "Rule not found" });
   res.json({ deleted: true, rule_id: req.params.ruleId });
 }));
 
+const MAX_GROUPS_PER_RUN = 500;
+
 /** POST /rules/:ruleId/run — Execute a correlation rule */
-router.post("/rules/:ruleId/run", wrapRoute("run correlation rule", function(req, res) {
+router.post("/rules/:ruleId/run", wrapRoute("run correlation rule", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var rule = db.prepare("SELECT * FROM correlation_rules WHERE rule_id = ?").get(req.params.ruleId);
+  const db = dbMod.getDb();
+  const rule = db.prepare("SELECT * FROM correlation_rules WHERE rule_id = ?").get(req.params.ruleId);
   if (!rule) return res.status(404).json({ error: "Rule not found" });
 
-  // Validate lookback_minutes if provided
-  var lookback = null;
+  let lookback = null;
   if (req.body.lookback_minutes !== undefined) {
     lookback = parseInt(req.body.lookback_minutes);
-    if (!Number.isFinite(lookback) || lookback < 1 || lookback > 10080) {
-      return res.status(400).json({ error: "lookback_minutes must be 1-10080 (max 7 days)" });
+    if (!Number.isFinite(lookback) || lookback < 1 || lookback > MAX_LOOKBACK_MINUTES) {
+      return res.status(400).json({ error: `lookback_minutes must be 1-${MAX_LOOKBACK_MINUTES} (max 7 days)` });
     }
   }
 
-  var groups = runCorrelation(rule, lookback);
-  // Cap groups to prevent excessive memory/DB usage from a single run
-  var MAX_GROUPS_PER_RUN = 500;
+  let groups = runCorrelation(rule, lookback);
   if (groups.length > MAX_GROUPS_PER_RUN) {
     groups = groups.slice(0, MAX_GROUPS_PER_RUN);
   }
-  var persisted = [];
+
+  let persisted = [];
   if (req.body.persist !== false) persisted = persistGroups(rule, groups);
 
-  var totalEvts = 0;
-  for (var g = 0; g < groups.length; g++) totalEvts += groups[g].events.length;
+  let totalEvts = 0;
+  for (const g of groups) totalEvts += g.events.length;
 
-  var outGroups;
-  if (persisted.length > 0) {
-    outGroups = persisted;
-  } else {
-    outGroups = [];
-    for (var g2 = 0; g2 < groups.length; g2++) {
-      outGroups.push({ label: groups[g2].label, member_count: groups[g2].events.length, metadata: groups[g2].metadata });
-    }
-  }
+  const outGroups = persisted.length > 0
+    ? persisted
+    : groups.map(g => ({ label: g.label, member_count: g.events.length, metadata: g.metadata }));
 
   res.json({
     rule_id: rule.rule_id, rule_name: rule.name, match_type: rule.match_type,
@@ -625,69 +594,61 @@ router.post("/rules/:ruleId/run", wrapRoute("run correlation rule", function(req
   });
 }));
 
-/** GET /groups — List correlation groups */
-// Optimized: member counts are computed via a LEFT JOIN subquery in a
-// single SQL statement instead of issuing N separate COUNT(*) queries
-// (one per group). This eliminates the N+1 query problem that caused
-// O(N) round-trips to SQLite on every list request.
-router.get("/groups", wrapRoute("list correlation groups", function(req, res) {
+/** GET /groups — List correlation groups
+ *  Member counts computed via LEFT JOIN subquery (eliminates N+1 queries). */
+router.get("/groups", wrapRoute("list correlation groups", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
+  const db = dbMod.getDb();
 
-  // Build WHERE clause
-  var whereClause = "";
-  var filterParams = [];
+  let whereClause = "";
+  const filterParams = [];
   if (req.query.rule_id) {
     whereClause = " WHERE g.rule_id = ?";
     filterParams.push(req.query.rule_id);
   }
 
-  var limit = parseLimit(req.query.limit, 50, 200);
-  var offset = parseOffset(req.query.offset);
+  const limit = parseLimit(req.query.limit, 50, 200);
+  const offset = parseOffset(req.query.offset);
 
-  // Single query: JOIN rule info + aggregate member counts via subquery
-  var query =
-    "SELECT g.*, r.name as rule_name, r.match_type, " +
-    "COALESCE(mc.member_count, 0) as member_count " +
-    "FROM correlation_groups g " +
-    "JOIN correlation_rules r ON g.rule_id = r.rule_id " +
-    "LEFT JOIN (" +
-    "  SELECT group_id, COUNT(*) as member_count FROM correlation_members GROUP BY group_id" +
-    ") mc ON g.group_id = mc.group_id" +
-    whereClause +
-    " ORDER BY g.created_at DESC LIMIT ? OFFSET ?";
+  const query = `
+    SELECT g.*, r.name as rule_name, r.match_type,
+      COALESCE(mc.member_count, 0) as member_count
+    FROM correlation_groups g
+    JOIN correlation_rules r ON g.rule_id = r.rule_id
+    LEFT JOIN (
+      SELECT group_id, COUNT(*) as member_count FROM correlation_members GROUP BY group_id
+    ) mc ON g.group_id = mc.group_id
+    ${whereClause}
+    ORDER BY g.created_at DESC LIMIT ? OFFSET ?`;
 
-  var params = filterParams.concat([limit, offset]);
-  var stmt = db.prepare(query);
-  var groups = stmt.all.apply(stmt, params);
-  for (var i = 0; i < groups.length; i++) { groups[i].metadata = safeJsonParse(groups[i].metadata); }
+  const groups = db.prepare(query).all(...filterParams, limit, offset);
+  for (const g of groups) g.metadata = safeJsonParse(g.metadata);
 
-  // Total count for pagination
-  var totalQuery = "SELECT COUNT(*) as cnt FROM correlation_groups" + (req.query.rule_id ? " WHERE rule_id = ?" : "");
-  var total;
-  if (req.query.rule_id) { total = db.prepare(totalQuery).get(req.query.rule_id).cnt; }
-  else { total = db.prepare(totalQuery).get().cnt; }
+  const totalQuery = `SELECT COUNT(*) as cnt FROM correlation_groups${req.query.rule_id ? " WHERE rule_id = ?" : ""}`;
+  const total = req.query.rule_id
+    ? db.prepare(totalQuery).get(req.query.rule_id).cnt
+    : db.prepare(totalQuery).get().cnt;
 
-  res.json({ groups: groups, total: total, limit: limit, offset: offset });
+  res.json({ groups, total, limit, offset });
 }));
 
 /** GET /groups/:groupId — Get group details with members */
-router.get("/groups/:groupId", wrapRoute("get correlation group", function(req, res) {
+router.get("/groups/:groupId", wrapRoute("get correlation group", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var group = db.prepare(
-    "SELECT g.*, r.name as rule_name, r.match_type FROM correlation_groups g " +
-    "JOIN correlation_rules r ON g.rule_id = r.rule_id WHERE g.group_id = ?"
+  const db = dbMod.getDb();
+  const group = db.prepare(
+    `SELECT g.*, r.name as rule_name, r.match_type FROM correlation_groups g
+     JOIN correlation_rules r ON g.rule_id = r.rule_id WHERE g.group_id = ?`
   ).get(req.params.groupId);
   if (!group) return res.status(404).json({ error: "Group not found" });
   group.metadata = safeJsonParse(group.metadata);
 
-  var members = db.prepare(
-    "SELECT m.*, e.event_type, e.timestamp, e.model, e.duration_ms, s.agent_name " +
-    "FROM correlation_members m " +
-    "JOIN events e ON m.event_id = e.event_id " +
-    "JOIN sessions s ON m.session_id = s.session_id " +
-    "WHERE m.group_id = ? ORDER BY e.timestamp ASC"
+  const members = db.prepare(
+    `SELECT m.*, e.event_type, e.timestamp, e.model, e.duration_ms, s.agent_name
+     FROM correlation_members m
+     JOIN events e ON m.event_id = e.event_id
+     JOIN sessions s ON m.session_id = s.session_id
+     WHERE m.group_id = ? ORDER BY e.timestamp ASC`
   ).all(req.params.groupId);
 
   group.members = members;
@@ -696,26 +657,26 @@ router.get("/groups/:groupId", wrapRoute("get correlation group", function(req, 
 }));
 
 /** DELETE /groups/:groupId — Delete a correlation group */
-router.delete("/groups/:groupId", wrapRoute("delete correlation group", function(req, res) {
+router.delete("/groups/:groupId", wrapRoute("delete correlation group", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var result = db.prepare("DELETE FROM correlation_groups WHERE group_id = ?").run(req.params.groupId);
+  const db = dbMod.getDb();
+  const result = db.prepare("DELETE FROM correlation_groups WHERE group_id = ?").run(req.params.groupId);
   if (result.changes === 0) return res.status(404).json({ error: "Group not found" });
   res.json({ deleted: true, group_id: req.params.groupId });
 }));
 
 /** GET /stats — Correlation statistics */
-router.get("/stats", wrapRoute("correlation stats", function(req, res) {
+router.get("/stats", wrapRoute("correlation stats", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var ruleCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_rules").get().cnt;
-  var enabledCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_rules WHERE enabled = 1").get().cnt;
-  var groupCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_groups").get().cnt;
-  var memberCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_members").get().cnt;
+  const db = dbMod.getDb();
+  const ruleCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_rules").get().cnt;
+  const enabledCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_rules WHERE enabled = 1").get().cnt;
+  const groupCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_groups").get().cnt;
+  const memberCount = db.prepare("SELECT COUNT(*) as cnt FROM correlation_members").get().cnt;
 
-  var byType = db.prepare(
-    "SELECT r.match_type, COUNT(g.group_id) as groups FROM correlation_rules r " +
-    "LEFT JOIN correlation_groups g ON r.rule_id = g.rule_id GROUP BY r.match_type"
+  const byType = db.prepare(
+    `SELECT r.match_type, COUNT(g.group_id) as groups FROM correlation_rules r
+     LEFT JOIN correlation_groups g ON r.rule_id = g.rule_id GROUP BY r.match_type`
   ).all();
 
   res.json({
@@ -726,28 +687,28 @@ router.get("/stats", wrapRoute("correlation stats", function(req, res) {
 }));
 
 /** GET /event/:eventId — Find all correlations for an event */
-router.get("/event/:eventId", wrapRoute("find event correlations", function(req, res) {
+router.get("/event/:eventId", wrapRoute("find event correlations", (req, res) => {
   ensureCorrelationTables();
-  var db = dbMod.getDb();
-  var memberships = db.prepare(
-    "SELECT m.group_id, m.role, g.label, g.created_at, g.metadata, r.name as rule_name, r.match_type " +
-    "FROM correlation_members m JOIN correlation_groups g ON m.group_id = g.group_id " +
-    "JOIN correlation_rules r ON g.rule_id = r.rule_id WHERE m.event_id = ? ORDER BY g.created_at DESC"
+  const db = dbMod.getDb();
+  const memberships = db.prepare(
+    `SELECT m.group_id, m.role, g.label, g.created_at, g.metadata, r.name as rule_name, r.match_type
+     FROM correlation_members m JOIN correlation_groups g ON m.group_id = g.group_id
+     JOIN correlation_rules r ON g.rule_id = r.rule_id WHERE m.event_id = ? ORDER BY g.created_at DESC`
   ).all(req.params.eventId);
-  for (var i = 0; i < memberships.length; i++) { memberships[i].metadata = safeJsonParse(memberships[i].metadata); }
+  for (const m of memberships) m.metadata = safeJsonParse(m.metadata);
   res.json({ event_id: req.params.eventId, correlations: memberships, total: memberships.length });
 }));
 
 // ── Export for testing ──────────────────────────────────────────────
 router._engine = {
-  correlateByMetadata: correlateByMetadata,
-  correlateByTimeWindow: correlateByTimeWindow,
-  correlateByErrorCascade: correlateByErrorCascade,
-  correlateByCausalChain: correlateByCausalChain,
-  correlateByCustom: correlateByCustom,
-  runCorrelation: runCorrelation,
-  persistGroups: persistGroups,
-  ensureCorrelationTables: ensureCorrelationTables,
+  correlateByMetadata,
+  correlateByTimeWindow,
+  correlateByErrorCascade,
+  correlateByCausalChain,
+  correlateByCustom,
+  runCorrelation,
+  persistGroups,
+  ensureCorrelationTables,
 };
 
 module.exports = router;

--- a/backend/routes/sessions.js
+++ b/backend/routes/sessions.js
@@ -546,23 +546,16 @@ router.post("/compare", wrapRoute("compare sessions", (req, res) => {
     // Compute deltas (B relative to A)
     const deltas = computeDeltas(metricsA, metricsB);
 
-    // All unique event types across both
-    const allEventTypes = [...new Set([
-      ...Object.keys(metricsA.event_types),
-      ...Object.keys(metricsB.event_types),
-    ])];
-
-    // All unique tools across both
-    const allTools = [...new Set([
-      ...Object.keys(metricsA.tools),
-      ...Object.keys(metricsB.tools),
-    ])];
-
-    // All unique models across both
-    const allModels = [...new Set([
-      ...Object.keys(metricsA.models),
-      ...Object.keys(metricsB.models),
-    ])];
+    // Collect unique keys across both sessions in a single helper
+    // to avoid creating 6 intermediate arrays and 3 Sets.
+    function mergeKeys(objA, objB) {
+      const set = new Set(Object.keys(objA));
+      for (const k of Object.keys(objB)) set.add(k);
+      return [...set];
+    }
+    const allEventTypes = mergeKeys(metricsA.event_types, metricsB.event_types);
+    const allTools = mergeKeys(metricsA.tools, metricsB.tools);
+    const allModels = mergeKeys(metricsA.models, metricsB.models);
 
     res.json({
       compared_at: new Date().toISOString(),
@@ -727,18 +720,22 @@ router.get("/:id/events/search", requireSessionId, wrapRoute("search events", (r
     // Parse JSON columns
     const parsed = dbResults.map(parseEventRow);
 
-    // ── Compute summary stats (only for this page — avoids loading all) ──
-    const totalTokensIn = parsed.reduce((s, e) => s + (e.tokens_in || 0), 0);
-    const totalTokensOut = parsed.reduce((s, e) => s + (e.tokens_out || 0), 0);
-    const totalDuration = parsed.reduce((s, e) => s + (e.duration_ms || 0), 0);
+    // ── Compute summary stats in a single pass (avoids 4 iterations) ──
+    let totalTokensIn = 0;
+    let totalTokensOut = 0;
+    let totalDuration = 0;
     const eventTypes = {};
     const models = {};
-    parsed.forEach((e) => {
+    for (let i = 0; i < parsed.length; i++) {
+      const e = parsed[i];
+      totalTokensIn += e.tokens_in || 0;
+      totalTokensOut += e.tokens_out || 0;
+      totalDuration += e.duration_ms || 0;
       eventTypes[e.event_type] = (eventTypes[e.event_type] || 0) + 1;
       if (e.model) {
         models[e.model] = (models[e.model] || 0) + 1;
       }
-    });
+    }
 
     res.json({
       session_id: id,

--- a/backend/routes/webhooks.js
+++ b/backend/routes/webhooks.js
@@ -9,6 +9,7 @@ const router = express.Router();
 const { getDb } = require("../db");
 const { validateWebhookUrl } = require("../lib/validation");
 const { parseLimit, wrapRoute } = require("../lib/request-helpers");
+const { generateId, isValidResourceId } = require("../lib/id-helpers");
 
 // ── Stricter rate limit for outbound webhook requests ───────────────
 // The /test and fire endpoints trigger outbound HTTP requests to
@@ -76,20 +77,16 @@ function ensureWebhooksTable() {
   _tableReady = true;
 }
 
-function generateId() {
-  return `${Date.now().toString(36)}-${crypto.randomBytes(6).toString("hex")}`;
-}
-
-// Validate webhookId: alphanumeric + hyphens, max 64 chars
-const WEBHOOK_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$/;
-
-function validateWebhookId(id) {
-  return typeof id === "string" && WEBHOOK_ID_RE.test(id);
-}
+// Middleware: reject invalid webhook IDs early
+router.param("webhookId", (req, res, next, val) => {
+  if (!isValidResourceId(val)) {
+    return res.status(400).json({ error: "Invalid webhook ID format" });
+  }
+  next();
+});
 
 // ── Shared response formatter ───────────────────────────────────────
-// Consolidates 3 identical inline mapping blocks that mask secrets
-// and parse rule_ids JSON for the API response.
+// Masks secrets and parses rule_ids JSON for the API response.
 
 function formatWebhookResponse(w) {
   return {
@@ -99,14 +96,6 @@ function formatWebhookResponse(w) {
     secret: w.secret ? "••••••" : null,
   };
 }
-
-// Middleware: reject invalid webhook IDs early
-router.param("webhookId", (req, res, next, val) => {
-  if (!validateWebhookId(val)) {
-    return res.status(400).json({ error: "Invalid webhook ID format" });
-  }
-  next();
-});
 
 // Middleware: ensure table exists (once per process, not per request)
 router.use((req, res, next) => {


### PR DESCRIPTION
## What

Consolidates duplicated ID generation and validation patterns across 3 route files into a single shared module.

## Changes

- **New file:** \ackend/lib/id-helpers.js\ ΓÇö exports \generateId()\, \isValidResourceId()\, \alidateIdParam()\, and \RESOURCE_ID_RE\
- **alerts.js:** Removed duplicate \SAFE_ID_RE\, \RESOURCE_ID_RE\, \isValidResourceId()\, \alidateIdParam()\, and \generateId()\. Removed redundant per-route \alidateIdParam()\ middleware (already handled by \outer.param()\)
- **webhooks.js:** Removed duplicate \WEBHOOK_ID_RE\, \alidateWebhookId()\, and \generateId()\
- **annotations.js:** Removed duplicate \generateId()\, now uses shared \generateId('ann')\ for prefixed IDs

## Why

- 3 identical \generateId()\ implementations
- 3 identical ID validation regexes (\SAFE_ID_RE\, \RESOURCE_ID_RE\, \WEBHOOK_ID_RE\)
- alerts.js had *double* ID validation (both \outer.param()\ and per-route \alidateIdParam()\ middleware)

## Testing

- Webhooks: 22/22 tests pass Γ£à
- Annotations: 38/38 tests pass Γ£à
- Alerts: validation tests pass; pre-existing DB setup failures unrelated to this change
