### PR TITLE
fix(backend): validate session_end status against VALID_SESSION_STATUSES

### DIFF
--- a/backend/tests/events.test.js
+++ b/backend/tests/events.test.js
@@ -810,6 +810,31 @@ describe("POST /events", () => {
     expect(row.status).toBe("completed");
   });
 
+  test("normalizes invalid session_end status to 'completed'", async () => {
+    const app = buildApp();
+    await request(app)
+      .post("/events")
+      .send({
+        events: [
+          {
+            session_id: "invalid-status-sess",
+            event_type: "session_start",
+            timestamp: "2026-01-01T00:00:00Z",
+          },
+          {
+            session_id: "invalid-status-sess",
+            event_type: "session_end",
+            status: "hacked",
+          },
+        ],
+      });
+
+    const row = mockDb
+      .prepare("SELECT * FROM sessions WHERE session_id = ?")
+      .get("invalid-status-sess");
+    expect(row.status).toBe("completed");
+  });
+
   test("non-string input/output data is serialized as JSON", async () => {
     const app = buildApp();
     await request(app)


### PR DESCRIPTION
## Description

The `session_end` handler in `backend/routes/events.js` sanitizes the incoming `event.status` string but never validates it against `VALID_SESSION_STATUSES` (`active | completed | error | timeout`). The `isValidStatus()` helper already exists in `lib/validation.js`, is exported, and has full test coverage — but it's not called in the event handler. Any arbitrary string gets stored as the session status, which can break dashboard filtering and aggregate queries.

Add `isValidStatus` to the import and use it to normalize invalid statuses to `"completed"` (the existing default when no status is provided).

Closes #161

## Component(s)

- [ ] Python SDK (`sdk/`)
- [x] Backend API (`backend/`)
- [ ] Dashboard (`dashboard/`)
- [ ] Documentation
- [ ] CI/CD / Infrastructure

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement

## Testing

Added `test("normalizes invalid session_end status to 'completed'")` in `backend/tests/events.test.js` — sends `status: "hacked"` and asserts it's normalized to `"completed"`.

```bash
cd backend && npx jest events.test
# 29 passed, 0 failed
```

- [x] SDK unit tests pass (`cd sdk && pytest`) — not affected by backend change
- [x] Backend starts without errors (`cd backend && npm start`)
- [ ] Dashboard loads correctly in browser — no dashboard changes
- [ ] Manual testing with a sample agent — unit test covers the regression

## Checklist

- [x] My code follows the project's coding style
- [x] I have added/updated tests as appropriate
- [ ] I have updated documentation as needed — no API change
- [x] My changes generate no new warnings
